### PR TITLE
Implement Builder's Club support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ config.ini
 *.log
 *.zip
 .DS_Store
+compile.bat
+run.bat
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,15 @@
                     <show>public</show>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -154,6 +163,13 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.13.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql
+++ b/sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql
@@ -1,0 +1,55 @@
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- =====================================================
+-- Update 4.0.3-beta to 4.0.4-beta
+-- =====================================================
+
+ALTER TABLE `catalog_pages`
+    ADD COLUMN IF NOT EXISTS `catalog_type` ENUM('NORMAL', 'BUILDERS_CLUB') NOT NULL DEFAULT 'NORMAL' AFTER `page_layout`;
+
+ALTER TABLE `catalog_items`
+    ADD COLUMN IF NOT EXISTS `subscription_type` VARCHAR(64) NULL DEFAULT NULL AFTER `offer_id`,
+    ADD COLUMN IF NOT EXISTS `subscription_days` INT NULL DEFAULT NULL AFTER `subscription_type`;
+
+ALTER TABLE `users_settings`
+    ADD COLUMN IF NOT EXISTS `builders_club_furni_limit` INT NOT NULL DEFAULT 0 AFTER `max_friends`,
+    ADD COLUMN IF NOT EXISTS `builders_club_max_furni_limit` INT NOT NULL DEFAULT 0 AFTER `builders_club_furni_limit`;
+
+CREATE TABLE IF NOT EXISTS `builders_club_item_sequence` (
+  `id` TINYINT NOT NULL,
+  `next_id` INT NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `items_item_sequence` (
+  `id` TINYINT NOT NULL,
+  `next_id` INT NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO `builders_club_item_sequence` (`id`, `next_id`)
+VALUES (1, 2147418113)
+ON DUPLICATE KEY UPDATE `next_id` = `next_id`;
+
+INSERT INTO `items_item_sequence` (`id`, `next_id`)
+SELECT 1, COALESCE(MAX(`id`), 0) + 1
+FROM `items`
+WHERE `id` < 2147418112
+ON DUPLICATE KEY UPDATE `next_id` = `next_id`;
+
+INSERT INTO `emulator_settings` (`key`, `value`) VALUES
+('builders.club.enabled', '0'),
+('builders.club.furni.limit', '0'),
+('builders.club.max.furni.limit', '0'),
+('builders.club.box.furni.limit.increment', '750'),
+('builders.club.grace.seconds', '0'),
+('builders.club.furniture.placement.group.room.enabled', '0'),
+('builders.club.expiry.action', 'none'),
+('builders.club.achievement', 'BuildersClub'),
+('builders.club.buy_membership_page', ''),
+('builders.club.try_page', ''),
+('builders.club.furnidata.url', '')
+ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql
+++ b/sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql
@@ -13,8 +13,8 @@ ALTER TABLE `catalog_items`
     ADD COLUMN IF NOT EXISTS `subscription_days` INT NULL DEFAULT NULL AFTER `subscription_type`;
 
 ALTER TABLE `users_settings`
-    ADD COLUMN IF NOT EXISTS `builders_club_furni_limit` INT NOT NULL DEFAULT 0 AFTER `max_friends`,
-    ADD COLUMN IF NOT EXISTS `builders_club_max_furni_limit` INT NOT NULL DEFAULT 0 AFTER `builders_club_furni_limit`;
+    ADD COLUMN IF NOT EXISTS `builders_club_furni_limit` INT NOT NULL DEFAULT 50 AFTER `max_friends`,
+    ADD COLUMN IF NOT EXISTS `builders_club_max_furni_limit` INT NOT NULL DEFAULT 50 AFTER `builders_club_furni_limit`;
 
 -- Add BC flag column to items
 ALTER TABLE `items`
@@ -44,8 +44,8 @@ DEALLOCATE PREPARE stmt;
 
 INSERT INTO `emulator_settings` (`key`, `value`) VALUES
 ('builders.club.enabled', '0'),
-('builders.club.furni.limit', '0'),
-('builders.club.max.furni.limit', '0'),
+('builders.club.furni.limit', '50'),
+('builders.club.max.furni.limit', '250'),
 ('builders.club.box.furni.limit.increment', '750'),
 ('builders.club.grace.seconds', '0'),
 ('builders.club.furniture.placement.group.room.enabled', '0'),
@@ -53,7 +53,10 @@ INSERT INTO `emulator_settings` (`key`, `value`) VALUES
 ('builders.club.achievement', 'BuildersClub'),
 ('builders.club.buy_membership_page', ''),
 ('builders.club.try_page', ''),
-('builders.club.furnidata.url', '')
+('builders.club.furnidata.url', ''),
+('builders.club.free_trial.enabled', '1'),
+('builders.club.free_trial.limit', '50'),
+('builders.club.expiry.warning.seconds', '86400')
 ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql
+++ b/sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql
@@ -16,27 +16,31 @@ ALTER TABLE `users_settings`
     ADD COLUMN IF NOT EXISTS `builders_club_furni_limit` INT NOT NULL DEFAULT 0 AFTER `max_friends`,
     ADD COLUMN IF NOT EXISTS `builders_club_max_furni_limit` INT NOT NULL DEFAULT 0 AFTER `builders_club_furni_limit`;
 
-CREATE TABLE IF NOT EXISTS `builders_club_item_sequence` (
-  `id` TINYINT NOT NULL,
-  `next_id` INT NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+-- Add BC flag column to items
+ALTER TABLE `items`
+    ADD COLUMN IF NOT EXISTS `is_builders_club` TINYINT(1) NOT NULL DEFAULT 0 AFTER `wired_data`;
 
-CREATE TABLE IF NOT EXISTS `items_item_sequence` (
-  `id` TINYINT NOT NULL,
-  `next_id` INT NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+-- Add index for BC furni count queries (MariaDB 10.2 compatible)
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'items' AND INDEX_NAME = 'idx_items_bc');
+SET @sql_idx = IF(@idx_exists = 0, 'ALTER TABLE `items` ADD INDEX `idx_items_bc` (`user_id`, `is_builders_club`, `room_id`)', 'SELECT 1');
+PREPARE stmt_idx FROM @sql_idx;
+EXECUTE stmt_idx;
+DEALLOCATE PREPARE stmt_idx;
 
-INSERT INTO `builders_club_item_sequence` (`id`, `next_id`)
-VALUES (1, 2147418113)
-ON DUPLICATE KEY UPDATE `next_id` = `next_id`;
+-- Drop old sequence tables
+DROP TABLE IF EXISTS `builders_club_item_sequence`;
+DROP TABLE IF EXISTS `items_item_sequence`;
 
-INSERT INTO `items_item_sequence` (`id`, `next_id`)
-SELECT 1, COALESCE(MAX(`id`), 0) + 1
-FROM `items`
-WHERE `id` < 2147418112
-ON DUPLICATE KEY UPDATE `next_id` = `next_id`;
+-- Purge any old BC items (IDs in the reserved range)
+DELETE FROM `items` WHERE `id` >= 2147418112;
+
+-- Reset AUTO_INCREMENT to be safe (after purging BC items)
+-- This dynamically sets it to MAX(id) + 1
+SET @max_id = (SELECT COALESCE(MAX(`id`), 0) + 1 FROM `items` WHERE `id` < 2147418112);
+SET @sql = CONCAT('ALTER TABLE `items` AUTO_INCREMENT = ', @max_id);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 INSERT INTO `emulator_settings` (`key`, `value`) VALUES
 ('builders.club.enabled', '0'),

--- a/src/main/java/com/eu/habbo/habbohotel/catalog/BuildersClubCatalogRegistry.java
+++ b/src/main/java/com/eu/habbo/habbohotel/catalog/BuildersClubCatalogRegistry.java
@@ -1,0 +1,139 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.habbohotel.items.Item;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BuildersClubCatalogRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuildersClubCatalogRegistry.class);
+
+    private final Set<Integer> compatibleOfferIds;
+    private final Set<Integer> compatibleBaseItemIds;
+    private final Set<String> compatiblePairs;
+
+    public BuildersClubCatalogRegistry() {
+        this(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+    }
+
+    private BuildersClubCatalogRegistry(Set<Integer> compatibleOfferIds, Set<Integer> compatibleBaseItemIds, Set<String> compatiblePairs) {
+        this.compatibleOfferIds = compatibleOfferIds;
+        this.compatibleBaseItemIds = compatibleBaseItemIds;
+        this.compatiblePairs = compatiblePairs;
+    }
+
+    public static BuildersClubCatalogRegistry load(String url) {
+        if (url == null || url.isBlank()) {
+            return new BuildersClubCatalogRegistry();
+        }
+
+        try (InputStream stream = new URL(url).openStream()) {
+            return parse(stream);
+        } catch (Exception e) {
+            LOGGER.error("Failed to load Builder's Club furnidata from {}", url, e);
+            return new BuildersClubCatalogRegistry();
+        }
+    }
+
+    static BuildersClubCatalogRegistry parse(InputStream stream) throws Exception {
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stream);
+        document.getDocumentElement().normalize();
+
+        Set<Integer> offerIds = new HashSet<>();
+        Set<Integer> baseItemIds = new HashSet<>();
+        Set<String> pairs = new HashSet<>();
+
+        parseEntries(document.getElementsByTagName("furnitype"), offerIds, baseItemIds, pairs);
+        parseEntries(document.getElementsByTagName("wallitemtype"), offerIds, baseItemIds, pairs);
+
+        return new BuildersClubCatalogRegistry(
+                Collections.unmodifiableSet(offerIds),
+                Collections.unmodifiableSet(baseItemIds),
+                Collections.unmodifiableSet(pairs)
+        );
+    }
+
+    private static void parseEntries(NodeList nodes, Set<Integer> offerIds, Set<Integer> baseItemIds, Set<String> pairs) {
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (!(node instanceof Element element)) {
+                continue;
+            }
+
+            int baseItemId = parseInt(element.getAttribute("id"));
+            int offerId = parseInt(childText(element, "offerid"));
+            boolean buildersClub = "1".equals(childText(element, "bc"));
+
+            if (!buildersClub || baseItemId <= 0 || offerId <= 0) {
+                continue;
+            }
+
+            offerIds.add(offerId);
+            baseItemIds.add(baseItemId);
+            pairs.add(pairKey(baseItemId, offerId));
+        }
+    }
+
+    private static String childText(Element element, String name) {
+        NodeList nodes = element.getElementsByTagName(name);
+        if (nodes.getLength() == 0 || nodes.item(0) == null) {
+            return "";
+        }
+
+        return nodes.item(0).getTextContent().trim();
+    }
+
+    private static int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    private static String pairKey(int baseItemId, int offerId) {
+        return baseItemId + ":" + offerId;
+    }
+
+    public boolean isCompatible(int baseItemId, int offerId) {
+        return baseItemId > 0
+                && offerId > 0
+                && this.compatiblePairs.contains(pairKey(baseItemId, offerId));
+    }
+
+    public boolean hasCompatibleOffer(int offerId) {
+        return this.compatibleOfferIds.contains(offerId);
+    }
+
+    public boolean hasCompatibleBaseItem(int baseItemId) {
+        return this.compatibleBaseItemIds.contains(baseItemId);
+    }
+
+    public boolean matches(CatalogItem item) {
+        if (item == null || item.getOfferId() <= 0) {
+            return false;
+        }
+
+        for (Item baseItem : item.getBaseItems()) {
+            if (baseItem != null && isCompatible(baseItem.getId(), item.getOfferId())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public int size() {
+        return this.compatiblePairs.size();
+    }
+}

--- a/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
@@ -46,6 +46,8 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
 
 
     private int orderNumber;
+    private String subscriptionType;
+    private int subscriptionDays;
 
 
     private HashMap<Integer, Integer> bundle;
@@ -99,6 +101,8 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         this.haveOffer = set.getBoolean("have_offer");
         this.offerId = set.getInt("offer_id");
         this.orderNumber = set.getInt("order_number");
+        this.subscriptionType = readNullableString(set, "subscription_type");
+        this.subscriptionDays = readNullableInt(set, "subscription_days");
 
         this.bundle = new HashMap<>();
         this.loadBundle();
@@ -174,6 +178,36 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         return this.offerId;
     }
 
+    public int getWireId() {
+        return this.offerId > 0 ? this.offerId : this.id;
+    }
+
+    public String getSubscriptionType() {
+        return this.subscriptionType;
+    }
+
+    public int getSubscriptionDays() {
+        return this.subscriptionDays;
+    }
+
+    public boolean isSubscriptionOffer() {
+        return this.subscriptionType != null && !this.subscriptionType.isBlank() && this.subscriptionDays > 0;
+    }
+
+    public boolean hasBaseItems() {
+        return !this.getBaseItems().isEmpty();
+    }
+
+    public boolean isSimpleSingleItemOffer() {
+        return this.amount == 1
+                && this.itemId != null
+                && !this.itemId.isBlank()
+                && !this.itemId.equals("0")
+                && !this.itemId.contains(";")
+                && !this.itemId.contains(":")
+                && this.getBaseItems().size() == 1;
+    }
+
     public boolean isLimited() {
         return this.limitedStack > 0;
     }
@@ -244,6 +278,10 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
     }
 
     public void loadBundle() {
+        if (this.itemId == null || this.itemId.isEmpty() || this.itemId.equals("0")) {
+            return;
+        }
+
         int intItemId;
 
         if (this.itemId.contains(";")) {
@@ -281,7 +319,7 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
 
     @Override
     public void serialize(ServerMessage message) {
-        message.appendInt(this.getId());
+        message.appendInt(this.getWireId());
         message.appendString(this.getName());
         message.appendBoolean(false);
         message.appendInt(this.getCredits());
@@ -338,6 +376,22 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         message.appendBoolean(haveOffer(this));
         message.appendBoolean(false); //unknown
         message.appendString(this.name + ".png");
+    }
+
+    private static String readNullableString(ResultSet set, String column) {
+        try {
+            return set.getString(column);
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+
+    private static int readNullableInt(ResultSet set, String column) {
+        try {
+            return set.getInt(column);
+        } catch (SQLException e) {
+            return 0;
+        }
     }
 
     @Override

--- a/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -184,6 +184,7 @@ public class CatalogManager {
     public static int catalogItemAmount;
     public static int PURCHASE_COOLDOWN = 1;
     public static boolean SORT_USING_ORDERNUM = false;
+    public static String BUILDERS_CLUB_FURNIDATA_URL = "";
     public final TIntObjectMap<CatalogPage> catalogPages;
     public final TIntObjectMap<CatalogFeaturedPage> catalogFeaturedPages;
     public final THashMap<Integer, THashSet<Item>> prizes;
@@ -197,6 +198,7 @@ public class CatalogManager {
     public final Item ecotronItem;
     public final THashMap<Integer, CatalogLimitedConfiguration> limitedNumbers;
     private final List<Voucher> vouchers;
+    private BuildersClubCatalogRegistry buildersClubCatalogRegistry;
 
     public CatalogManager() {
         long millis = System.currentTimeMillis();
@@ -212,6 +214,7 @@ public class CatalogManager {
         this.offerDefs = new TIntIntHashMap();
         this.vouchers = new ArrayList<>();
         this.limitedNumbers = new THashMap<>();
+        this.buildersClubCatalogRegistry = new BuildersClubCatalogRegistry();
 
         this.initialize();
 
@@ -228,6 +231,7 @@ public class CatalogManager {
         this.loadCatalogPages();
         this.loadCatalogFeaturedPages();
         this.loadCatalogItems();
+        this.reloadBuildersClubCatalogRegistry();
         this.loadClubOffers();
         this.loadTargetOffers();
         this.loadVouchers();
@@ -341,11 +345,14 @@ public class CatalogManager {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_items")) {
             CatalogItem item;
             while (set.next()) {
-                if (set.getString("item_ids").equals("0"))
+                CatalogItem loadedItem = new CatalogItem(set);
+
+                if (set.getString("item_ids").equals("0") && !loadedItem.isSubscriptionOffer()) {
                     continue;
+                }
 
                 if (set.getString("catalog_name").contains("HABBO_CLUB_")) {
-                    this.clubItems.add(new CatalogItem(set));
+                    this.clubItems.add(loadedItem);
                     continue;
                 }
 
@@ -358,7 +365,7 @@ public class CatalogManager {
 
                 if (item == null) {
                     catalogItemAmount++;
-                    item = new CatalogItem(set);
+                    item = loadedItem;
                     page.addItem(item);
 
                     if (item.getOfferId() != -1) {
@@ -386,6 +393,11 @@ public class CatalogManager {
                 }
             }
         }
+    }
+
+    public synchronized void reloadBuildersClubCatalogRegistry() {
+        this.buildersClubCatalogRegistry = BuildersClubCatalogRegistry.load(BUILDERS_CLUB_FURNIDATA_URL);
+        LOGGER.info("Loaded {} Builder's Club furnidata mappings", this.buildersClubCatalogRegistry.size());
     }
 
     private void loadClubOffers() {
@@ -582,10 +594,30 @@ public class CatalogManager {
         return this.catalogPages.get(pageId);
     }
 
+    public CatalogPage getCatalogPage(int pageId, CatalogPageMode mode) {
+        CatalogPage page = this.getCatalogPage(pageId);
+
+        if (page == null || page.getCatalogType() != mode) {
+            return null;
+        }
+
+        return page;
+    }
+
     public CatalogPage getCatalogPage(String captionSafe) {
         return this.catalogPages.valueCollection().stream()
                 .filter(p -> p != null && p.getPageName() != null && p.getPageName().equalsIgnoreCase(captionSafe))
                 .findAny().orElse(null);
+    }
+
+    public CatalogPage getCatalogPage(String captionSafe, CatalogPageMode mode) {
+        CatalogPage page = this.getCatalogPage(captionSafe);
+
+        if (page == null || page.getCatalogType() != mode) {
+            return null;
+        }
+
+        return page;
     }
 
     public CatalogPage getCatalogPageByLayout(String layoutName) {
@@ -615,20 +647,48 @@ public class CatalogManager {
         return item[0];
     }
 
+    public CatalogItem getCatalogItemByOfferId(int offerId) {
+        if (offerId <= 0) {
+            return null;
+        }
+
+        int catalogItemId = this.offerDefs.get(offerId);
+        if (catalogItemId > 0) {
+            return this.getCatalogItem(catalogItemId);
+        }
+
+        return null;
+    }
+
+    public CatalogItem getCatalogItemByWireId(int wireId) {
+        if (wireId <= 0) {
+            return null;
+        }
+
+        CatalogItem item = this.getCatalogItemByOfferId(wireId);
+        if (item != null) {
+            return item;
+        }
+
+        return this.getCatalogItem(wireId);
+    }
+
 
     public List<CatalogPage> getCatalogPages(int parentId, final Habbo habbo) {
-        final List<CatalogPage> pages = new ArrayList<>();
+        return this.getCatalogPages(parentId, habbo, CatalogPageMode.NORMAL);
+    }
 
-        this.catalogPages.get(parentId).childPages.forEachValue(new TObjectProcedure<CatalogPage>() {
+    public List<CatalogPage> getCatalogPages(int parentId, final Habbo habbo, final CatalogPageMode mode) {
+        final List<CatalogPage> pages = new ArrayList<>();
+        CatalogPage parent = this.catalogPages.get(parentId);
+        if (parent == null) {
+            return pages;
+        }
+
+        parent.childPages.forEachValue(new TObjectProcedure<CatalogPage>() {
             @Override
             public boolean execute(CatalogPage object) {
-
-                boolean isVisiblePage = object.visible;
-                boolean hasRightRank = object.getRank() <= habbo.getHabboInfo().getRank().getId();
-
-                boolean clubRightsOkay = !object.isClubOnly() || habbo.getHabboInfo().getHabboStats().hasActiveClub();
-
-                if (isVisiblePage && hasRightRank && clubRightsOkay) {
+                if (canViewPage(object, habbo, mode)) {
                     pages.add(object);
                 }
                 return true;
@@ -637,6 +697,129 @@ public class CatalogManager {
         Collections.sort(pages);
 
         return pages;
+    }
+
+    public CatalogItem getCatalogItemByOfferId(CatalogPage page, int offerId) {
+        if (page == null || offerId <= 0) {
+            return null;
+        }
+
+        for (CatalogItem item : page.getCatalogItems().valueCollection()) {
+            if (item != null && item.getOfferId() == offerId) {
+                return item;
+            }
+        }
+
+        return null;
+    }
+
+    public CatalogItem getCatalogItemByWireId(CatalogPage page, int wireId) {
+        if (page == null || wireId <= 0) {
+            return null;
+        }
+
+        CatalogItem item = this.getCatalogItemByOfferId(page, wireId);
+        if (item != null) {
+            return item;
+        }
+
+        return page.getCatalogItem(wireId);
+    }
+
+    public List<CatalogItem> getVisibleCatalogItems(CatalogPage page, Habbo habbo, CatalogPageMode mode) {
+        List<CatalogItem> items = new ArrayList<>();
+        if (page == null) {
+            return items;
+        }
+
+        for (CatalogItem item : page.getCatalogItems().valueCollection()) {
+            if (item == null) {
+                continue;
+            }
+
+            if (item.isClubOnly() && !habbo.getHabboStats().hasActiveClub()) {
+                continue;
+            }
+
+            if (mode.isBuildersClub() && !isBuildersClubVisibleItem(page, item)) {
+                continue;
+            }
+
+            items.add(item);
+        }
+
+        Collections.sort(items);
+        return items;
+    }
+
+    public boolean isBuildersClubPlaceableItem(CatalogPage page, CatalogItem item) {
+        if (page == null || item == null || page.getCatalogType() != CatalogPageMode.BUILDERS_CLUB) {
+            return false;
+        }
+
+        if (!shouldFilterBuildersClubPlacementPage(page)) {
+            return false;
+        }
+
+        if (item.isSubscriptionOffer() || item.getOfferId() <= 0 || !item.hasBaseItems()) {
+            return false;
+        }
+
+        if (!this.buildersClubCatalogRegistry.matches(item)) {
+            return false;
+        }
+
+        if (!item.isSimpleSingleItemOffer()) {
+            return false;
+        }
+
+        for (Item baseItem : item.getBaseItems()) {
+            if (baseItem == null) {
+                return false;
+            }
+
+            if (baseItem.getType() != FurnitureType.FLOOR && baseItem.getType() != FurnitureType.WALL) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public BuildersClubCatalogRegistry getBuildersClubCatalogRegistry() {
+        return this.buildersClubCatalogRegistry;
+    }
+
+    private boolean canViewPage(CatalogPage page, Habbo habbo, CatalogPageMode mode) {
+        if (page == null || page.getCatalogType() != mode) {
+            return false;
+        }
+
+        boolean isVisiblePage = page.visible;
+        boolean hasRightRank = page.getRank() <= habbo.getHabboInfo().getRank().getId();
+        boolean clubRightsOkay = !page.isClubOnly() || habbo.getHabboInfo().getHabboStats().hasActiveClub();
+
+        return isVisiblePage && hasRightRank && clubRightsOkay;
+    }
+
+    private boolean isBuildersClubVisibleItem(CatalogPage page, CatalogItem item) {
+        if (!shouldFilterBuildersClubPlacementPage(page)) {
+            return true;
+        }
+
+        return isBuildersClubPlaceableItem(page, item);
+    }
+
+    private boolean shouldFilterBuildersClubPlacementPage(CatalogPage page) {
+        if (page == null || page.getCatalogType() != CatalogPageMode.BUILDERS_CLUB) {
+            return false;
+        }
+
+        if (page.getLayout() == null) {
+            return true;
+        }
+
+        return !page.getLayout().equalsIgnoreCase(CatalogPageLayouts.builders_club_addons.name())
+                && !page.getLayout().equalsIgnoreCase(CatalogPageLayouts.builders_club_loyalty.name());
     }
 
     public TIntObjectMap<CatalogFeaturedPage> getCatalogFeaturedPages() {
@@ -886,6 +1069,27 @@ public class CatalogManager {
                 if (totalCredits > 0 && habbo.getHabboInfo().getCredits() - totalCredits < 0) return;
                 if (totalPoints > 0 && habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()) - totalPoints < 0)
                     return;
+
+                if (item.isSubscriptionOffer()) {
+                    int totalDays = item.getSubscriptionDays() * amount;
+
+                    if (!free && !habbo.hasPermission(Permission.ACC_INFINITE_CREDITS) && totalCredits > 0) {
+                        habbo.giveCredits(-totalCredits);
+                    }
+
+                    if (!free && !habbo.hasPermission(Permission.ACC_INFINITE_POINTS) && totalPoints > 0) {
+                        habbo.givePoints(item.getPointsType(), -totalPoints);
+                    }
+
+                    if (habbo.getHabboStats().createSubscription(item.getSubscriptionType(), totalDays * 86400) == null) {
+                        habbo.getClient().sendResponse(new PurchaseErrorMessageComposer(PurchaseErrorMessageComposer.SERVER_ERROR));
+                        return;
+                    }
+
+                    habbo.getClient().sendResponse(new PurchaseOKMessageComposer(item));
+                    habbo.getClient().sendResponse(new FurniListInvalidateMessageComposer());
+                    return;
+                }
 
                 List<String> badges = new ArrayList<>();
                 Map<UnseenItemsMessageComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();

--- a/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
+++ b/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
@@ -40,6 +40,7 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
     protected String textTwo;
     protected String textDetails;
     protected String textTeaser;
+    protected CatalogPageMode catalogType = CatalogPageMode.NORMAL;
 
     public CatalogPage() {
     }
@@ -67,6 +68,7 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
         this.textTwo = set.getString("page_text2");
         this.textDetails = set.getString("page_text_details");
         this.textTeaser = set.getString("page_text_teaser");
+        this.catalogType = readCatalogType(set);
 
         if (!set.getString("includes").isEmpty()) {
             for (String id : set.getString("includes").split(";")) {
@@ -160,6 +162,10 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
         return this.textTeaser;
     }
 
+    public CatalogPageMode getCatalogType() {
+        return this.catalogType;
+    }
+
     public TIntArrayList getOfferIds() {
         return this.offerIds;
     }
@@ -204,4 +210,12 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
 
     @Override
     public abstract void serialize(ServerMessage message);
+
+    private CatalogPageMode readCatalogType(ResultSet set) {
+        try {
+            return CatalogPageMode.fromClientMode(set.getString("catalog_type"));
+        } catch (SQLException e) {
+            return CatalogPageMode.NORMAL;
+        }
+    }
 }

--- a/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPageMode.java
+++ b/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPageMode.java
@@ -1,0 +1,34 @@
+package com.eu.habbo.habbohotel.catalog;
+
+public enum CatalogPageMode {
+    NORMAL("NORMAL"),
+    BUILDERS_CLUB("BUILDERS_CLUB");
+
+    private final String clientMode;
+
+    CatalogPageMode(String clientMode) {
+        this.clientMode = clientMode;
+    }
+
+    public String getClientMode() {
+        return this.clientMode;
+    }
+
+    public boolean isBuildersClub() {
+        return this == BUILDERS_CLUB;
+    }
+
+    public static CatalogPageMode fromClientMode(String clientMode) {
+        if (clientMode == null) {
+            return NORMAL;
+        }
+
+        for (CatalogPageMode value : values()) {
+            if (value.clientMode.equalsIgnoreCase(clientMode)) {
+                return value;
+            }
+        }
+
+        return NORMAL;
+    }
+}

--- a/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
+++ b/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
@@ -230,6 +230,7 @@ public class CommandHandler {
         addCommand(new MutePetsCommand());
         addCommand(new PetInfoCommand());
         addCommand(new PickallCommand());
+        addCommand(new PickallBcCommand());
         addCommand(new PixelCommand());
         addCommand(new PluginsCommand());
         addCommand(new PointsCommand());

--- a/src/main/java/com/eu/habbo/habbohotel/commands/PickallBcCommand.java
+++ b/src/main/java/com/eu/habbo/habbohotel/commands/PickallBcCommand.java
@@ -1,0 +1,23 @@
+package com.eu.habbo.habbohotel.commands;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
+
+public class PickallBcCommand extends Command {
+    public PickallBcCommand() {
+        super("cmd_pickall", new String[]{"pickallbc"});
+    }
+
+    @Override
+    public boolean handle(GameClient gameClient, String[] params) throws Exception {
+        Room room = gameClient.getHabbo().getHabboInfo().getCurrentRoom();
+
+        if (room != null && room.isOwner(gameClient.getHabbo())) {
+            room.pickUpBuildersClubItems(gameClient.getHabbo().getHabboInfo().getId(), gameClient.getHabbo());
+            SubscriptionBuildersClub.pushCatalogState(gameClient.getHabbo());
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/eu/habbo/habbohotel/commands/UpdateCatalogCommand.java
+++ b/src/main/java/com/eu/habbo/habbohotel/commands/UpdateCatalogCommand.java
@@ -3,6 +3,8 @@ package com.eu.habbo.habbohotel.commands;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.messages.outgoing.catalog.*;
 import com.eu.habbo.messages.outgoing.catalog.marketplace.MarketplaceConfigurationMessageComposer;
 
@@ -16,11 +18,16 @@ public class UpdateCatalogCommand extends Command {
     public boolean handle(GameClient gameClient, String[] params) {
         Emulator.getGameEnvironment().getCatalogManager().initialize();
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new CatalogPublishedMessageComposer());
-        Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new BuildersClubFurniCountMessageComposer(0));
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new BundleDiscountRulesetMessageComposer());
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new MarketplaceConfigurationMessageComposer());
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new GiftWrappingConfigurationMessageComposer());
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new RecyclerPrizesMessageComposer());
+        for (GameClient client : Emulator.getGameServer().getGameClientManager().getSessions().values()) {
+            Habbo habbo = client.getHabbo();
+            if (habbo != null && habbo.getClient() != null) {
+                SubscriptionBuildersClub.pushCatalogState(habbo);
+            }
+        }
         Emulator.getGameEnvironment().getCraftingManager().reload();
         gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.succes.cmd_update_catalog"), RoomChatMessageBubbles.ALERT);
         return true;

--- a/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -52,6 +52,7 @@ import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.*;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.messages.outgoing.inventory.UnseenItemsMessageComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadItemsManagerEvent;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
@@ -478,25 +479,33 @@ public class ItemManager {
     }
 
     public HabboItem createItem(int habboId, Item item, int limitedStack, int limitedSells, String extraData) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
-            statement.setInt(1, habboId);
-            statement.setInt(2, item.getId());
-            statement.setString(3, extraData);
-            statement.setString(4, limitedStack + ":" + limitedSells);
+        int itemId = this.allocateRegularItemId();
+        if (itemId <= 0) {
+            return null;
+        }
+
+        return this.createItem(itemId, habboId, item, limitedStack, limitedSells, extraData);
+    }
+
+    public HabboItem createItem(int id, int habboId, Item item, int limitedStack, int limitedSells, String extraData) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement("INSERT INTO items (id, user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?, ?)")) {
+            statement.setInt(1, id);
+            statement.setInt(2, habboId);
+            statement.setInt(3, item.getId());
+            statement.setString(4, extraData);
+            statement.setString(5, limitedStack + ":" + limitedSells);
             statement.execute();
 
-            try (ResultSet set = statement.getGeneratedKeys()) {
-                if (set.next()) {
-                    Class<? extends HabboItem> itemClass = item.getInteractionType().getType();
+            Class<? extends HabboItem> itemClass = item.getInteractionType().getType();
 
-                    if (itemClass != null) {
-                        try {
-                            return itemClass.getDeclaredConstructor(int.class, int.class, Item.class, String.class, int.class, int.class).newInstance(set.getInt(1), habboId, item, extraData, limitedStack, limitedSells);
-                        } catch (Exception e) {
-                            LOGGER.error("Caught exception", e);
-                            return new InteractionDefault(set.getInt(1), habboId, item, extraData, limitedStack, limitedSells);
-                        }
-                    }
+            if (itemClass != null) {
+                try {
+                    return itemClass.getDeclaredConstructor(int.class, int.class, Item.class, String.class, int.class, int.class)
+                            .newInstance(id, habboId, item, extraData, limitedStack, limitedSells);
+                } catch (Exception e) {
+                    LOGGER.error("Caught exception", e);
+                    return new InteractionDefault(id, habboId, item, extraData, limitedStack, limitedSells);
                 }
             }
         } catch (SQLException e) {
@@ -504,7 +513,119 @@ public class ItemManager {
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
         }
+
         return null;
+    }
+
+    public HabboItem createBuildersClubItem(int habboId, Item item, String extraData) {
+        return this.createItem(this.allocateBuildersClubItemId(), habboId, item, 0, 0, extraData);
+    }
+
+    public synchronized int allocateRegularItemId() {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            connection.setAutoCommit(false);
+
+            try {
+                int nextId;
+
+                try (PreparedStatement select = connection.prepareStatement("SELECT next_id FROM items_item_sequence WHERE id = 1 FOR UPDATE");
+                     ResultSet set = select.executeQuery()) {
+                    if (set.next()) {
+                        nextId = set.getInt("next_id");
+                    } else {
+                        nextId = this.initializeRegularItemSequence(connection);
+                        connection.commit();
+                        return nextId;
+                    }
+                }
+
+                if (nextId >= SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START) {
+                    throw new SQLException("Regular item id sequence reached reserved Builder's Club range");
+                }
+
+                try (PreparedStatement update = connection.prepareStatement("UPDATE items_item_sequence SET next_id = ? WHERE id = 1")) {
+                    update.setInt(1, nextId + 1);
+                    update.executeUpdate();
+                }
+
+                connection.commit();
+                return nextId;
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to allocate regular item id", e);
+        }
+
+        return 0;
+    }
+
+    public synchronized int allocateBuildersClubItemId() {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            connection.setAutoCommit(false);
+
+            try {
+                int nextId = SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START;
+
+                try (PreparedStatement select = connection.prepareStatement("SELECT next_id FROM builders_club_item_sequence WHERE id = 1 FOR UPDATE");
+                     ResultSet set = select.executeQuery()) {
+                    if (set.next()) {
+                        nextId = set.getInt("next_id");
+                    } else {
+                        try (PreparedStatement insert = connection.prepareStatement("INSERT INTO builders_club_item_sequence (id, next_id) VALUES (1, ?)")) {
+                            insert.setInt(1, SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START + 1);
+                            insert.executeUpdate();
+                            connection.commit();
+                            return SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START;
+                        }
+                    }
+                }
+
+                try (PreparedStatement update = connection.prepareStatement("UPDATE builders_club_item_sequence SET next_id = ? WHERE id = 1")) {
+                    update.setInt(1, nextId + 1);
+                    update.executeUpdate();
+                }
+
+                connection.commit();
+                return nextId;
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to allocate Builder's Club item id", e);
+        }
+
+        return SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START;
+    }
+
+    private int initializeRegularItemSequence(Connection connection) throws SQLException {
+        int nextId = 1;
+
+        try (PreparedStatement maxStatement = connection.prepareStatement("SELECT COALESCE(MAX(id), 0) + 1 FROM items WHERE id < ?")) {
+            maxStatement.setInt(1, SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START);
+            try (ResultSet set = maxStatement.executeQuery()) {
+                if (set.next()) {
+                    nextId = Math.max(1, set.getInt(1));
+                }
+            }
+        }
+
+        if (nextId >= SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START) {
+            throw new SQLException("Cannot initialize regular item id sequence inside reserved Builder's Club range");
+        }
+
+        try (PreparedStatement insert = connection.prepareStatement("INSERT INTO items_item_sequence (id, next_id) VALUES (1, ?)")) {
+            insert.setInt(1, nextId + 1);
+            insert.executeUpdate();
+        }
+
+        return nextId;
     }
 
     public void loadNewUserGifts() {

--- a/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -52,10 +52,11 @@ import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.*;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
+
 import com.eu.habbo.messages.outgoing.inventory.UnseenItemsMessageComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadItemsManagerEvent;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
+import java.sql.Statement;
 import gnu.trove.TCollections;
 import gnu.trove.iterator.TIntObjectIterator;
 import gnu.trove.map.TIntObjectMap;
@@ -73,7 +74,7 @@ public class ItemManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemManager.class);
 
-    //Configuration. Loaded from database & updated accordingly.
+    // Configuration. Loaded from database & updated accordingly.
     public static boolean RECYCLER_ENABLED = true;
 
     private final TIntObjectMap<Item> items;
@@ -185,14 +186,17 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("handitem_tile", InteractionHanditemTile.class));
         this.interactionsList.add(new ItemInteraction("effect_giver", InteractionEffectGiver.class));
         this.interactionsList.add(new ItemInteraction("effect_vendingmachine", InteractionEffectVendingMachine.class));
-        this.interactionsList.add(new ItemInteraction("effect_vendingmachine_no_sides", InteractionEffectVendingMachineNoSides.class));
+        this.interactionsList.add(
+                new ItemInteraction("effect_vendingmachine_no_sides", InteractionEffectVendingMachineNoSides.class));
         this.interactionsList.add(new ItemInteraction("crackable_monster", InteractionMonsterCrackable.class));
         this.interactionsList.add(new ItemInteraction("snowboard_slope", InteractionSnowboardSlope.class));
         this.interactionsList.add(new ItemInteraction("pressureplate_group", InteractionGroupPressurePlate.class));
         this.interactionsList.add(new ItemInteraction("effect_tile_group", InteractionEffectTile.class));
-        this.interactionsList.add(new ItemInteraction("crackable_subscription_box", InteractionRedeemableSubscriptionBox.class));
+        this.interactionsList
+                .add(new ItemInteraction("crackable_subscription_box", InteractionRedeemableSubscriptionBox.class));
         this.interactionsList.add(new ItemInteraction("random_state", InteractionRandomState.class));
-        this.interactionsList.add(new ItemInteraction("vendingmachine_no_sides", InteractionNoSidesVendingMachine.class));
+        this.interactionsList
+                .add(new ItemInteraction("vendingmachine_no_sides", InteractionNoSidesVendingMachine.class));
         this.interactionsList.add(new ItemInteraction("tile_walkmagic", InteractionTileWalkMagic.class));
 
         this.interactionsList.add(new ItemInteraction("game_timer", InteractionGameTimer.class));
@@ -214,7 +218,6 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_score_achieved", WiredTriggerScoreAchieved.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_win", WiredTriggerTeamWins.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_lose", WiredTriggerTeamLoses.class));
-
 
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_reset_timers", WiredEffectResetTimers.class));
@@ -265,7 +268,8 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_wearing_b", WiredConditionNotHabboWearsBadge.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_in_group", WiredConditionNotInGroup.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_in_team", WiredConditionNotInTeam.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_match_snap", WiredConditionNotMatchStatePosition.class));
+        this.interactionsList
+                .add(new ItemInteraction("wf_cnd_not_match_snap", WiredConditionNotMatchStatePosition.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_trggrer_on", WiredConditionNotTriggerOnFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_actor_in_team", WiredConditionTeamMember.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_trggrer_on_frn", WiredConditionTriggerOnFurni.class));
@@ -273,68 +277,67 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_date_rng_active", WiredConditionDateRangeActive.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_valid_moves", WiredConditionMovementValidation.class));
 
-
         this.interactionsList.add(new ItemInteraction("wf_xtra_random", WiredExtraRandom.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_unseen", WiredExtraUnseen.class));
         this.interactionsList.add(new ItemInteraction("wf_blob", WiredBlob.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_or_eval", WiredExtraOrEval.class));
 
-
         this.interactionsList.add(new ItemInteraction("wf_highscore", InteractionWiredHighscore.class));
 
-
         this.interactionsList.add(new ItemInteraction("battlebanzai_tile", InteractionBattleBanzaiTile.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_random_teleport", InteractionBattleBanzaiTeleporter.class));
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_random_teleport", InteractionBattleBanzaiTeleporter.class));
         this.interactionsList.add(new ItemInteraction("battlebanzai_sphere", InteractionBattleBanzaiSphere.class));
         this.interactionsList.add(new ItemInteraction("battlebanzai_puck", InteractionBattleBanzaiPuck.class));
 
-
         this.interactionsList.add(new ItemInteraction("battlebanzai_gate_blue", InteractionBattleBanzaiGateBlue.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_gate_green", InteractionBattleBanzaiGateGreen.class));
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_gate_green", InteractionBattleBanzaiGateGreen.class));
         this.interactionsList.add(new ItemInteraction("battlebanzai_gate_red", InteractionBattleBanzaiGateRed.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_gate_yellow", InteractionBattleBanzaiGateYellow.class));
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_gate_yellow", InteractionBattleBanzaiGateYellow.class));
 
-
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_blue", InteractionBattleBanzaiScoreboardBlue.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_green", InteractionBattleBanzaiScoreboardGreen.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_red", InteractionBattleBanzaiScoreboardRed.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_yellow", InteractionBattleBanzaiScoreboardYellow.class));
-
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_counter_blue", InteractionBattleBanzaiScoreboardBlue.class));
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_counter_green", InteractionBattleBanzaiScoreboardGreen.class));
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_counter_red", InteractionBattleBanzaiScoreboardRed.class));
+        this.interactionsList
+                .add(new ItemInteraction("battlebanzai_counter_yellow", InteractionBattleBanzaiScoreboardYellow.class));
 
         this.interactionsList.add(new ItemInteraction("freeze_block", InteractionFreezeBlock.class));
         this.interactionsList.add(new ItemInteraction("freeze_tile", InteractionFreezeTile.class));
         this.interactionsList.add(new ItemInteraction("freeze_exit", InteractionFreezeExitTile.class));
-
 
         this.interactionsList.add(new ItemInteraction("freeze_gate_blue", InteractionFreezeGateBlue.class));
         this.interactionsList.add(new ItemInteraction("freeze_gate_green", InteractionFreezeGateGreen.class));
         this.interactionsList.add(new ItemInteraction("freeze_gate_red", InteractionFreezeGateRed.class));
         this.interactionsList.add(new ItemInteraction("freeze_gate_yellow", InteractionFreezeGateYellow.class));
 
-
         this.interactionsList.add(new ItemInteraction("freeze_counter_blue", InteractionFreezeScoreboardBlue.class));
         this.interactionsList.add(new ItemInteraction("freeze_counter_green", InteractionFreezeScoreboardGreen.class));
         this.interactionsList.add(new ItemInteraction("freeze_counter_red", InteractionFreezeScoreboardRed.class));
-        this.interactionsList.add(new ItemInteraction("freeze_counter_yellow", InteractionFreezeScoreboardYellow.class));
-
+        this.interactionsList
+                .add(new ItemInteraction("freeze_counter_yellow", InteractionFreezeScoreboardYellow.class));
 
         this.interactionsList.add(new ItemInteraction("icetag_pole", InteractionIceTagPole.class));
         this.interactionsList.add(new ItemInteraction("icetag_field", InteractionIceTagField.class));
 
-
         this.interactionsList.add(new ItemInteraction("bunnyrun_pole", InteractionBunnyrunPole.class));
         this.interactionsList.add(new ItemInteraction("bunnyrun_field", InteractionBunnyrunField.class));
 
-
         this.interactionsList.add(new ItemInteraction("rollerskate_field", InteractionRollerskateField.class));
-
 
         this.interactionsList.add(new ItemInteraction("football", InteractionFootball.class));
         this.interactionsList.add(new ItemInteraction("football_gate", InteractionFootballGate.class));
-        this.interactionsList.add(new ItemInteraction("football_counter_blue", InteractionFootballScoreboardBlue.class));
-        this.interactionsList.add(new ItemInteraction("football_counter_green", InteractionFootballScoreboardGreen.class));
+        this.interactionsList
+                .add(new ItemInteraction("football_counter_blue", InteractionFootballScoreboardBlue.class));
+        this.interactionsList
+                .add(new ItemInteraction("football_counter_green", InteractionFootballScoreboardGreen.class));
         this.interactionsList.add(new ItemInteraction("football_counter_red", InteractionFootballScoreboardRed.class));
-        this.interactionsList.add(new ItemInteraction("football_counter_yellow", InteractionFootballScoreboardYellow.class));
+        this.interactionsList
+                .add(new ItemInteraction("football_counter_yellow", InteractionFootballScoreboardYellow.class));
         this.interactionsList.add(new ItemInteraction("football_goal_blue", InteractionFootballGoalBlue.class));
         this.interactionsList.add(new ItemInteraction("football_goal_green", InteractionFootballGoalGreen.class));
         this.interactionsList.add(new ItemInteraction("football_goal_red", InteractionFootballGoalRed.class));
@@ -351,18 +354,18 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("totem_planet", InteractionTotemPlanet.class));
     }
 
-
     public void addItemInteraction(ItemInteraction itemInteraction) {
         for (ItemInteraction interaction : this.interactionsList) {
             if (interaction.getType() == itemInteraction.getType() ||
                     interaction.getName().equalsIgnoreCase(itemInteraction.getName()))
 
-                throw new RuntimeException("Interaction Types must be unique. An class with type: " + interaction.getClass().getName() + " was already added OR the key: " + interaction.getName() + " is already in use.");
+                throw new RuntimeException(
+                        "Interaction Types must be unique. An class with type: " + interaction.getClass().getName()
+                                + " was already added OR the key: " + interaction.getName() + " is already in use.");
         }
 
         this.interactionsList.add(itemInteraction);
     }
-
 
     public ItemInteraction getItemInteraction(Class<? extends HabboItem> type) {
         for (ItemInteraction interaction : this.interactionsList) {
@@ -374,7 +377,6 @@ public class ItemManager {
         return this.getItemInteraction(InteractionDefault.class);
     }
 
-
     public ItemInteraction getItemInteraction(String type) {
         for (ItemInteraction interaction : this.interactionsList) {
             if (interaction.getName().equalsIgnoreCase(type))
@@ -384,16 +386,14 @@ public class ItemManager {
         return this.getItemInteraction(InteractionDefault.class);
     }
 
-
     public void loadItems() {
         try (
                 Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                 Statement statement = connection.createStatement();
-                ResultSet set = statement.executeQuery(("SELECT * FROM items_base ORDER BY id DESC"))
-        ) {
+                ResultSet set = statement.executeQuery(("SELECT * FROM items_base ORDER BY id DESC"))) {
             while (set.next()) {
                 try {
-                    //Item proxyItem =
+                    // Item proxyItem =
                     int id = set.getInt("id");
                     if (!this.items.containsKey(id))
                         this.items.put(id, new Item(set));
@@ -409,10 +409,11 @@ public class ItemManager {
         }
     }
 
-
     public void loadCrackable() {
         this.crackableRewards.clear();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_crackable"); ResultSet set = statement.executeQuery()) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_crackable");
+                ResultSet set = statement.executeQuery()) {
             while (set.next()) {
                 CrackableReward reward;
                 try {
@@ -431,14 +432,12 @@ public class ItemManager {
         }
     }
 
-
     public int getCrackableCount(int itemId) {
         if (this.crackableRewards.containsKey(itemId))
             return this.crackableRewards.get(itemId).count;
         else
             return 0;
     }
-
 
     public int calculateCrackState(int count, int max, Item baseItem) {
         return (int) Math.floor((1.0D / ((double) max / (double) count) * baseItem.getStateCount()));
@@ -452,11 +451,12 @@ public class ItemManager {
         return this.getItem(this.crackableRewards.get(itemId).getRandomReward());
     }
 
-
     public void loadSoundTracks() {
         this.soundTracks.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM soundtracks"); ResultSet set = statement.executeQuery()) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM soundtracks");
+                ResultSet set = statement.executeQuery()) {
             while (set.next()) {
                 this.soundTracks.put(set.getString("code"), new SoundTrack(set));
             }
@@ -479,33 +479,47 @@ public class ItemManager {
     }
 
     public HabboItem createItem(int habboId, Item item, int limitedStack, int limitedSells, String extraData) {
-        int itemId = this.allocateRegularItemId();
-        if (itemId <= 0) {
-            return null;
-        }
-
-        return this.createItem(itemId, habboId, item, limitedStack, limitedSells, extraData);
+        return this.createItemInternal(habboId, item, limitedStack, limitedSells, extraData, false);
     }
 
-    public HabboItem createItem(int id, int habboId, Item item, int limitedStack, int limitedSells, String extraData) {
+    private HabboItem createItemInternal(int habboId, Item item, int limitedStack, int limitedSells, String extraData,
+            boolean isBuildersClub) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("INSERT INTO items (id, user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?, ?)")) {
-            statement.setInt(1, id);
-            statement.setInt(2, habboId);
-            statement.setInt(3, item.getId());
-            statement.setString(4, extraData);
-            statement.setString(5, limitedStack + ":" + limitedSells);
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO items (user_id, item_id, extra_data, limited_data, is_builders_club) VALUES (?, ?, ?, ?, ?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
+            statement.setInt(1, habboId);
+            statement.setInt(2, item.getId());
+            statement.setString(3, extraData);
+            statement.setString(4, limitedStack + ":" + limitedSells);
+            statement.setInt(5, isBuildersClub ? 1 : 0);
             statement.execute();
 
-            Class<? extends HabboItem> itemClass = item.getInteractionType().getType();
+            try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    int id = generatedKeys.getInt(1);
 
-            if (itemClass != null) {
-                try {
-                    return itemClass.getDeclaredConstructor(int.class, int.class, Item.class, String.class, int.class, int.class)
-                            .newInstance(id, habboId, item, extraData, limitedStack, limitedSells);
-                } catch (Exception e) {
-                    LOGGER.error("Caught exception", e);
-                    return new InteractionDefault(id, habboId, item, extraData, limitedStack, limitedSells);
+                    Class<? extends HabboItem> itemClass = item.getInteractionType().getType();
+
+                    HabboItem habboItem = null;
+                    if (itemClass != null) {
+                        try {
+                            habboItem = itemClass
+                                    .getDeclaredConstructor(int.class, int.class, Item.class, String.class, int.class,
+                                            int.class)
+                                    .newInstance(id, habboId, item, extraData, limitedStack, limitedSells);
+                        } catch (Exception e) {
+                            LOGGER.error("Caught exception", e);
+                            habboItem = new InteractionDefault(id, habboId, item, extraData, limitedStack,
+                                    limitedSells);
+                        }
+                    }
+
+                    if (habboItem != null && isBuildersClub) {
+                        habboItem.setBuildersClub(true);
+                    }
+
+                    return habboItem;
                 }
             }
         } catch (SQLException e) {
@@ -518,120 +532,14 @@ public class ItemManager {
     }
 
     public HabboItem createBuildersClubItem(int habboId, Item item, String extraData) {
-        return this.createItem(this.allocateBuildersClubItemId(), habboId, item, 0, 0, extraData);
-    }
-
-    public synchronized int allocateRegularItemId() {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            connection.setAutoCommit(false);
-
-            try {
-                int nextId;
-
-                try (PreparedStatement select = connection.prepareStatement("SELECT next_id FROM items_item_sequence WHERE id = 1 FOR UPDATE");
-                     ResultSet set = select.executeQuery()) {
-                    if (set.next()) {
-                        nextId = set.getInt("next_id");
-                    } else {
-                        nextId = this.initializeRegularItemSequence(connection);
-                        connection.commit();
-                        return nextId;
-                    }
-                }
-
-                if (nextId >= SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START) {
-                    throw new SQLException("Regular item id sequence reached reserved Builder's Club range");
-                }
-
-                try (PreparedStatement update = connection.prepareStatement("UPDATE items_item_sequence SET next_id = ? WHERE id = 1")) {
-                    update.setInt(1, nextId + 1);
-                    update.executeUpdate();
-                }
-
-                connection.commit();
-                return nextId;
-            } catch (SQLException e) {
-                connection.rollback();
-                throw e;
-            } finally {
-                connection.setAutoCommit(true);
-            }
-        } catch (SQLException e) {
-            LOGGER.error("Failed to allocate regular item id", e);
-        }
-
-        return 0;
-    }
-
-    public synchronized int allocateBuildersClubItemId() {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            connection.setAutoCommit(false);
-
-            try {
-                int nextId = SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START;
-
-                try (PreparedStatement select = connection.prepareStatement("SELECT next_id FROM builders_club_item_sequence WHERE id = 1 FOR UPDATE");
-                     ResultSet set = select.executeQuery()) {
-                    if (set.next()) {
-                        nextId = set.getInt("next_id");
-                    } else {
-                        try (PreparedStatement insert = connection.prepareStatement("INSERT INTO builders_club_item_sequence (id, next_id) VALUES (1, ?)")) {
-                            insert.setInt(1, SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START + 1);
-                            insert.executeUpdate();
-                            connection.commit();
-                            return SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START;
-                        }
-                    }
-                }
-
-                try (PreparedStatement update = connection.prepareStatement("UPDATE builders_club_item_sequence SET next_id = ? WHERE id = 1")) {
-                    update.setInt(1, nextId + 1);
-                    update.executeUpdate();
-                }
-
-                connection.commit();
-                return nextId;
-            } catch (SQLException e) {
-                connection.rollback();
-                throw e;
-            } finally {
-                connection.setAutoCommit(true);
-            }
-        } catch (SQLException e) {
-            LOGGER.error("Failed to allocate Builder's Club item id", e);
-        }
-
-        return SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START;
-    }
-
-    private int initializeRegularItemSequence(Connection connection) throws SQLException {
-        int nextId = 1;
-
-        try (PreparedStatement maxStatement = connection.prepareStatement("SELECT COALESCE(MAX(id), 0) + 1 FROM items WHERE id < ?")) {
-            maxStatement.setInt(1, SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START);
-            try (ResultSet set = maxStatement.executeQuery()) {
-                if (set.next()) {
-                    nextId = Math.max(1, set.getInt(1));
-                }
-            }
-        }
-
-        if (nextId >= SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START) {
-            throw new SQLException("Cannot initialize regular item id sequence inside reserved Builder's Club range");
-        }
-
-        try (PreparedStatement insert = connection.prepareStatement("INSERT INTO items_item_sequence (id, next_id) VALUES (1, ?)")) {
-            insert.setInt(1, nextId + 1);
-            insert.executeUpdate();
-        }
-
-        return nextId;
+        return this.createItemInternal(habboId, item, 0, 0, extraData, true);
     }
 
     public void loadNewUserGifts() {
         this.newuserGifts.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM nux_gifts")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM nux_gifts")) {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     this.newuserGifts.put(set.getInt("id"), new NewUserGift(set));
@@ -659,7 +567,8 @@ public class ItemManager {
     }
 
     public void deleteItem(HabboItem item) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE id = ?")) {
             statement.setInt(1, item.getId());
             statement.execute();
         } catch (SQLException e) {
@@ -668,22 +577,28 @@ public class ItemManager {
     }
 
     public HabboItem handleRecycle(Habbo habbo, String itemId) {
-        String extradata = Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-" + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-" + Calendar.getInstance().get(Calendar.YEAR);
+        String extradata = Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-"
+                + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-" + Calendar.getInstance().get(Calendar.YEAR);
 
         HabboItem item = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data) VALUES (?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO items (user_id, item_id, extra_data) VALUES (?, ?, ?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setInt(2, Emulator.getGameEnvironment().getCatalogManager().ecotronItem.getId());
             statement.setString(3, extradata);
             statement.execute();
 
             try (ResultSet set = statement.getGeneratedKeys()) {
-                try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO items_presents VALUES (?, ?)")) {
+                try (PreparedStatement preparedStatement = connection
+                        .prepareStatement("INSERT INTO items_presents VALUES (?, ?)")) {
                     while (set.next() && item == null) {
                         preparedStatement.setInt(1, set.getInt(1));
                         preparedStatement.setInt(2, Integer.parseInt(itemId));
                         preparedStatement.addBatch();
-                        item = new InteractionDefault(set.getInt(1), habbo.getHabboInfo().getId(), Emulator.getGameEnvironment().getCatalogManager().ecotronItem, extradata, 0, 0);
+                        item = new InteractionDefault(set.getInt(1), habbo.getHabboInfo().getId(),
+                                Emulator.getGameEnvironment().getCatalogManager().ecotronItem, extradata, 0, 0);
                     }
 
                     preparedStatement.executeBatch();
@@ -699,23 +614,28 @@ public class ItemManager {
     public HabboItem handleOpenRecycleBox(Habbo habbo, HabboItem box) {
         Emulator.getThreading().run(new QueryDeleteHabboItem(box.getId()));
         HabboItem item = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_presents WHERE item_id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection
+                        .prepareStatement("SELECT * FROM items_presents WHERE item_id = ? LIMIT 1")) {
             statement.setInt(1, box.getId());
             try (ResultSet rewardSet = statement.executeQuery()) {
                 if (rewardSet.next()) {
-                    try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO items (user_id, item_id) VALUES(?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                    try (PreparedStatement preparedStatement = connection.prepareStatement(
+                            "INSERT INTO items (user_id, item_id) VALUES(?, ?)", Statement.RETURN_GENERATED_KEYS)) {
                         preparedStatement.setInt(1, habbo.getHabboInfo().getId());
                         preparedStatement.setInt(2, rewardSet.getInt("base_item_reward"));
                         preparedStatement.execute();
 
                         try (ResultSet set = preparedStatement.getGeneratedKeys()) {
                             if (set.next()) {
-                                try (PreparedStatement request = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
+                                try (PreparedStatement request = connection
+                                        .prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
                                     request.setInt(1, set.getInt(1));
 
                                     try (ResultSet resultSet = request.executeQuery()) {
                                         if (resultSet.next()) {
-                                            try (PreparedStatement deleteStatement = connection.prepareStatement("DELETE FROM items_presents WHERE item_id = ? LIMIT 1")) {
+                                            try (PreparedStatement deleteStatement = connection.prepareStatement(
+                                                    "DELETE FROM items_presents WHERE item_id = ? LIMIT 1")) {
                                                 deleteStatement.setInt(1, box.getId());
                                                 deleteStatement.execute();
 
@@ -739,7 +659,9 @@ public class ItemManager {
     }
 
     public void insertTeleportPair(int itemOneId, int itemTwoId) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items_teleports VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection
+                        .prepareStatement("INSERT INTO items_teleports VALUES (?, ?)")) {
             statement.setInt(1, itemOneId);
             statement.setInt(2, itemTwoId);
             statement.execute();
@@ -749,7 +671,8 @@ public class ItemManager {
     }
 
     public void insertHopper(HabboItem hopper) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items_hoppers VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("INSERT INTO items_hoppers VALUES (?, ?)")) {
             statement.setInt(1, hopper.getId());
             statement.setInt(2, hopper.getBaseItem().getId());
             statement.execute();
@@ -759,13 +682,15 @@ public class ItemManager {
     }
 
     public int[] getTargetTeleportRoomId(HabboItem item) {
-        int[] a = new int[]{};
+        int[] a = new int[] {};
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT items.id, items.room_id FROM items_teleports INNER JOIN items ON items_teleports.teleport_one_id = items.id OR items_teleports.teleport_two_id = items.id WHERE items.id != ? AND items.room_id > 0 LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT items.id, items.room_id FROM items_teleports INNER JOIN items ON items_teleports.teleport_one_id = items.id OR items_teleports.teleport_two_id = items.id WHERE items.id != ? AND items.room_id > 0 LIMIT 1")) {
             statement.setInt(1, item.getId());
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
-                    a = new int[]{set.getInt("room_id"), set.getInt("id")};
+                    a = new int[] { set.getInt("room_id"), set.getInt("id") };
                 }
             }
         } catch (SQLException e) {
@@ -777,7 +702,8 @@ public class ItemManager {
 
     public HabboItem loadHabboItem(int itemId) {
         HabboItem item = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
             statement.setInt(1, itemId);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -822,9 +748,10 @@ public class ItemManager {
 
         if (habbo != null) {
             userId = habbo.getHabboInfo().getId();
-        }
-        else {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
+        } else {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection
+                            .prepareStatement("SELECT id FROM users WHERE username = ?")) {
                 statement.setString(1, username);
                 try (ResultSet set = statement.executeQuery()) {
                     if (set.next()) {
@@ -836,7 +763,7 @@ public class ItemManager {
             }
         }
 
-        if(userId > 0) {
+        if (userId > 0) {
             return createGift(userId, item, extraData, limitedStack, limitedSells);
         }
 
@@ -879,7 +806,7 @@ public class ItemManager {
     public Item getItem(String itemName) {
         TIntObjectIterator<Item> item = this.items.iterator();
 
-        for (int i = this.items.size(); i-- > 0; ) {
+        for (int i = this.items.size(); i-- > 0;) {
             try {
                 item.advance();
                 if (item.value().getName().equalsIgnoreCase(itemName)) {

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionCrackable.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionCrackable.java
@@ -127,7 +127,7 @@ public class InteractionCrackable extends HabboItem {
                                 habbo.getHabboStats().createSubscription(SubscriptionHabboClub.HABBO_CLUB, rewardData.subscriptionDuration * 86400);
                                 break;
                             case BUILDERS_CLUB:
-                                habbo.getHabboStats().createSubscription("BUILDERS_CLUB", rewardData.subscriptionDuration * 86400);
+                                habbo.getHabboStats().createBuildersClubBoxSubscription(rewardData.subscriptionDuration * 86400);
                                 break;
                         }
                     }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionDateRangeActive.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionDateRangeActive.java
@@ -39,7 +39,7 @@ public class WiredConditionDateRangeActive extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.startDate);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
@@ -30,7 +30,8 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
         this.items = new THashSet<>();
     }
 
-    public WiredConditionFurniHaveFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionFurniHaveFurni(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
         this.items = new THashSet<>();
     }
@@ -41,32 +42,41 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
 
         this.refresh();
 
-        if(this.items.isEmpty())
+        if (this.items.isEmpty())
             return true;
 
         if (room.getLayout() == null)
             return false;
 
-        if(this.all) {
+        if (this.all) {
             return this.items.stream().allMatch(item -> {
-                if (item == null) return false;
+                if (item == null)
+                    return false;
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
-                if (baseTile == null) return false;
+                if (baseTile == null)
+                    return false;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-                if (occupiedTiles == null) return false;
-                return occupiedTiles.stream().anyMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
+                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(),
+                        item.getBaseItem().getLength(), item.getRotation());
+                if (occupiedTiles == null)
+                    return false;
+                return occupiedTiles.stream().anyMatch(tile -> tile != null && room.getItemsAt(tile).stream()
+                        .anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
-        }
-        else {
+        } else {
             return this.items.stream().anyMatch(item -> {
-                if (item == null) return false;
+                if (item == null)
+                    return false;
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
-                if (baseTile == null) return false;
+                if (baseTile == null)
+                    return false;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-                if (occupiedTiles == null) return false;
-                return occupiedTiles.stream().anyMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
+                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(),
+                        item.getBaseItem().getLength(), item.getRotation());
+                if (occupiedTiles == null)
+                    return false;
+                return occupiedTiles.stream().anyMatch(tile -> tile != null && room.getItemsAt(tile).stream()
+                        .anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
         }
     }
@@ -82,8 +92,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
                 this.all,
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -94,8 +103,8 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.all = data.all;
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (int id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -112,7 +121,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
                     String[] items = data[1].split(";");
 
                     for (String s : items) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);
@@ -142,10 +151,10 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.all ? 1 : 0);
@@ -157,12 +166,14 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
 
     @Override
     public boolean saveData(WiredSettings settings) {
-        if(settings.getIntParams().length < 1) return false;
+        if (settings.getIntParams().length < 1)
+            return false;
 
         this.all = settings.getIntParams()[0] == 1;
 
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 
@@ -189,7 +200,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
@@ -32,7 +32,8 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
         this.items = new THashSet<>();
     }
 
-    public WiredConditionFurniHaveHabbo(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionFurniHaveHabbo(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
         this.items = new THashSet<>();
     }
@@ -60,12 +61,21 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
 
         return this.items.stream().filter(item -> item != null).allMatch(item -> {
             RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
-            if (baseTile == null) return false;
-            
-            THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-            return habbos.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
-                    bots.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
-                    pets.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()));
+            if (baseTile == null)
+                return false;
+
+            THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(),
+                    item.getBaseItem().getLength(), item.getRotation());
+            return habbos.stream()
+                    .anyMatch(character -> character.getRoomUnit() != null
+                            && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()))
+                    ||
+                    bots.stream()
+                            .anyMatch(character -> character.getRoomUnit() != null
+                                    && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()))
+                    ||
+                    pets.stream().anyMatch(character -> character.getRoomUnit() != null
+                            && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()));
         });
     }
 
@@ -79,8 +89,7 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
     public String getWiredData() {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -91,8 +100,8 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (int id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -106,7 +115,7 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
                 String[] items = data[1].split(";");
 
                 for (String s : items) {
-                    HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                    HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                     if (item != null)
                         this.items.add(item);
@@ -129,10 +138,10 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -145,7 +154,8 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
     public boolean saveData(WiredSettings settings) {
         int count = settings.getFurniIds().length;
 
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 
@@ -173,7 +183,7 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniTypeMatch.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniTypeMatch.java
@@ -27,7 +27,8 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         super(set, baseItem);
     }
 
-    public WiredConditionFurniTypeMatch(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionFurniTypeMatch(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
     }
 
@@ -40,7 +41,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
     public boolean evaluate(WiredContext ctx) {
         this.refresh();
 
-        if(items.isEmpty())
+        if (items.isEmpty())
             return false;
 
         HabboItem triggeringItem = ctx.sourceItem().orElse(null);
@@ -61,8 +62,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
     public String getWiredData() {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -73,8 +73,8 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (int id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -84,7 +84,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
             String[] data = wiredData.split(";");
 
             for (String s : data) {
-                HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                 if (item != null) {
                     this.items.add(item);
@@ -107,10 +107,10 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -122,7 +122,8 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
     @Override
     public boolean saveData(WiredSettings settings) {
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 
@@ -145,7 +146,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionGroupMember.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionGroupMember.java
@@ -68,7 +68,7 @@ public class WiredConditionGroupMember extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboCount.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboCount.java
@@ -81,7 +81,7 @@ public class WiredConditionHabboCount extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.lowerLimit);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboHasEffect.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboHasEffect.java
@@ -74,7 +74,7 @@ public class WiredConditionHabboHasEffect extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.effectId);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboHasHandItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboHasHandItem.java
@@ -41,7 +41,7 @@ public class WiredConditionHabboHasHandItem extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.handItem);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboWearsBadge.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboWearsBadge.java
@@ -87,7 +87,7 @@ public class WiredConditionHabboWearsBadge extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.badge);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionLessTimeElapsed.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionLessTimeElapsed.java
@@ -77,7 +77,7 @@ public class WiredConditionLessTimeElapsed extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.cycles);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMatchStatePosition.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMatchStatePosition.java
@@ -20,7 +20,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class WiredConditionMatchStatePosition extends InteractionWiredCondition implements InteractionWiredMatchFurniSettings {
+public class WiredConditionMatchStatePosition extends InteractionWiredCondition
+        implements InteractionWiredMatchFurniSettings {
     public static final WiredConditionType type = WiredConditionType.MATCH_SSHOT;
 
     private THashSet<WiredMatchFurniSetting> settings;
@@ -34,7 +35,8 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
         this.settings = new THashSet<>();
     }
 
-    public WiredConditionMatchStatePosition(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionMatchStatePosition(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
         this.settings = new THashSet<>();
     }
@@ -52,11 +54,13 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.settings.size());
 
-        for (WiredMatchFurniSetting item : this.settings)
-            message.appendInt(item.item_id);
+        for (WiredMatchFurniSetting setting : this.settings) {
+            HabboItem matchItem = room.getHabboItemByDatabaseId(setting.item_id);
+            message.appendInt(matchItem != null ? matchItem.getRoomVisibleId() : setting.item_id);
+        }
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(4);
         message.appendInt(this.state ? 1 : 0);
@@ -71,7 +75,8 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
 
     @Override
     public boolean saveData(WiredSettings settings) {
-        if(settings.getIntParams().length < 3) return false;
+        if (settings.getIntParams().length < 3)
+            return false;
         this.state = settings.getIntParams()[0] == 1;
         this.direction = settings.getIntParams()[1] == 1;
         this.position = settings.getIntParams()[2] == 1;
@@ -82,7 +87,8 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
             return true;
 
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.settings.clear();
 
@@ -91,7 +97,8 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
             HabboItem item = room.getHabboItem(itemId);
 
             if (item != null)
-                this.settings.add(new WiredMatchFurniSetting(item.getId(), item.getExtradata(), item.getRotation(), item.getX(), item.getY()));
+                this.settings.add(new WiredMatchFurniSetting(item.getId(), item.getExtradata(), item.getRotation(),
+                        item.getX(), item.getY()));
         }
 
         return true;
@@ -106,7 +113,7 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
         THashSet<WiredMatchFurniSetting> s = new THashSet<>();
 
         for (WiredMatchFurniSetting setting : this.settings) {
-            HabboItem item = room.getHabboItem(setting.item_id);
+            HabboItem item = room.getHabboItemByDatabaseId(setting.item_id);
 
             if (item != null) {
                 if (this.state) {
@@ -149,8 +156,7 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
                 this.state,
                 this.position,
                 this.direction,
-                new ArrayList<>(this.settings)
-        ));
+                new ArrayList<>(this.settings)));
     }
 
     @Override
@@ -174,7 +180,8 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
                 String[] stuff = items[i].split("-");
 
                 if (stuff.length >= 5)
-                    this.settings.add(new WiredMatchFurniSetting(Integer.parseInt(stuff[0]), stuff[1], Integer.parseInt(stuff[2]), Integer.parseInt(stuff[3]), Integer.parseInt(stuff[4])));
+                    this.settings.add(new WiredMatchFurniSetting(Integer.parseInt(stuff[0]), stuff[1],
+                            Integer.parseInt(stuff[2]), Integer.parseInt(stuff[3]), Integer.parseInt(stuff[4])));
             }
 
             this.state = data[2].equals("1");
@@ -198,7 +205,7 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
             THashSet<WiredMatchFurniSetting> remove = new THashSet<>();
 
             for (WiredMatchFurniSetting setting : this.settings) {
-                HabboItem item = room.getHabboItem(setting.item_id);
+                HabboItem item = room.getHabboItemByDatabaseId(setting.item_id);
                 if (item == null) {
                     remove.add(setting);
                 }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMoreTimeElapsed.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMoreTimeElapsed.java
@@ -77,7 +77,7 @@ public class WiredConditionMoreTimeElapsed extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.cycles);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMovementValidation.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMovementValidation.java
@@ -103,7 +103,7 @@ public class WiredConditionMovementValidation extends InteractionWiredCondition 
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveFurni.java
@@ -31,7 +31,8 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
         this.items = new THashSet<>();
     }
 
-    public WiredConditionNotFurniHaveFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionNotFurniHaveFurni(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
         this.items = new THashSet<>();
     }
@@ -48,26 +49,35 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
         if (room.getLayout() == null)
             return true;
 
-        if(this.all) {
+        if (this.all) {
             return this.items.stream().allMatch(item -> {
-                if (item == null) return true;
+                if (item == null)
+                    return true;
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
-                if (baseTile == null) return true;
+                if (baseTile == null)
+                    return true;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-                if (occupiedTiles == null) return true;
-                return occupiedTiles.stream().noneMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
+                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(),
+                        item.getBaseItem().getLength(), item.getRotation());
+                if (occupiedTiles == null)
+                    return true;
+                return occupiedTiles.stream().noneMatch(tile -> tile != null && room.getItemsAt(tile).stream()
+                        .anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
-        }
-        else {
+        } else {
             return this.items.stream().anyMatch(item -> {
-                if (item == null) return true;
+                if (item == null)
+                    return true;
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
-                if (baseTile == null) return true;
+                if (baseTile == null)
+                    return true;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-                if (occupiedTiles == null) return true;
-                return occupiedTiles.stream().noneMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
+                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(),
+                        item.getBaseItem().getLength(), item.getRotation());
+                if (occupiedTiles == null)
+                    return true;
+                return occupiedTiles.stream().noneMatch(tile -> tile != null && room.getItemsAt(tile).stream()
+                        .anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
         }
     }
@@ -83,8 +93,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
                 this.all,
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -97,7 +106,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
             this.all = data.all;
 
             for (int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -113,7 +122,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
                     String[] items = data[1].split(";");
 
                     for (String s : items) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);
@@ -143,10 +152,10 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.all ? 1 : 0);
@@ -158,11 +167,13 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
 
     @Override
     public boolean saveData(WiredSettings settings) {
-        if(settings.getIntParams().length < 1) return false;
+        if (settings.getIntParams().length < 1)
+            return false;
         this.all = settings.getIntParams()[0] == 1;
 
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 
@@ -189,7 +200,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }
@@ -201,8 +212,10 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
 
     @Override
     public WiredConditionOperator operator() {
-        // NICE TRY BUT THAT'S NOT HOW IT WORKS. NOTHING IN HABBO IS AN "OR" CONDITION - EVERY CONDITION MUST BE SUCCESS FOR THE STACK TO EXECUTE, BUT LET'S LEAVE IT IMPLEMENTED FOR PLUGINS TO USE.
-        //return this.all ? WiredConditionOperator.AND : WiredConditionOperator.OR;
+        // NICE TRY BUT THAT'S NOT HOW IT WORKS. NOTHING IN HABBO IS AN "OR" CONDITION -
+        // EVERY CONDITION MUST BE SUCCESS FOR THE STACK TO EXECUTE, BUT LET'S LEAVE IT
+        // IMPLEMENTED FOR PLUGINS TO USE.
+        // return this.all ? WiredConditionOperator.AND : WiredConditionOperator.OR;
         return WiredConditionOperator.AND;
     }
 

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveHabbo.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
     public static final WiredConditionType type = WiredConditionType.NOT_FURNI_HAVE_HABBO;
-    
+
     protected THashSet<HabboItem> items;
 
     public WiredConditionNotFurniHaveHabbo(ResultSet set, Item baseItem) throws SQLException {
@@ -33,7 +33,8 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
         this.items = new THashSet<>();
     }
 
-    public WiredConditionNotFurniHaveHabbo(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionNotFurniHaveHabbo(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
         this.items = new THashSet<>();
     }
@@ -61,12 +62,21 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
 
         return this.items.stream().filter(item -> item != null).noneMatch(item -> {
             RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
-            if (baseTile == null) return false;
-            
-            THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-            return habbos.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
-                    bots.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
-                    pets.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()));
+            if (baseTile == null)
+                return false;
+
+            THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(),
+                    item.getBaseItem().getLength(), item.getRotation());
+            return habbos.stream()
+                    .anyMatch(character -> character.getRoomUnit() != null
+                            && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()))
+                    ||
+                    bots.stream()
+                            .anyMatch(character -> character.getRoomUnit() != null
+                                    && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()))
+                    ||
+                    pets.stream().anyMatch(character -> character.getRoomUnit() != null
+                            && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation()));
         });
     }
 
@@ -80,8 +90,7 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
     public String getWiredData() {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -90,10 +99,11 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
         String wiredData = set.getString("wired_data");
 
         if (wiredData.startsWith("{")) {
-            WiredConditionFurniHaveHabbo.JsonData data = WiredManager.getGson().fromJson(wiredData, WiredConditionFurniHaveHabbo.JsonData.class);
+            WiredConditionFurniHaveHabbo.JsonData data = WiredManager.getGson().fromJson(wiredData,
+                    WiredConditionFurniHaveHabbo.JsonData.class);
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (int id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -106,7 +116,7 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
                 String[] items = data[1].split(";");
 
                 for (String s : items) {
-                    HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                    HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                     if (item != null)
                         this.items.add(item);
@@ -129,10 +139,10 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -144,7 +154,8 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
     @Override
     public boolean saveData(WiredSettings settings) {
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 
@@ -172,7 +183,7 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniTypeMatch.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniTypeMatch.java
@@ -27,7 +27,8 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
         super(set, baseItem);
     }
 
-    public WiredConditionNotFurniTypeMatch(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionNotFurniTypeMatch(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
     }
 
@@ -35,7 +36,7 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
     public boolean evaluate(WiredContext ctx) {
         this.refresh();
 
-        if(items.isEmpty())
+        if (items.isEmpty())
             return true;
 
         HabboItem triggeringItem = ctx.sourceItem().orElse(null);
@@ -56,8 +57,7 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
     public String getWiredData() {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -66,10 +66,11 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
         String wiredData = set.getString("wired_data");
 
         if (wiredData.startsWith("{")) {
-            WiredConditionFurniTypeMatch.JsonData data = WiredManager.getGson().fromJson(wiredData, WiredConditionFurniTypeMatch.JsonData.class);
+            WiredConditionFurniTypeMatch.JsonData data = WiredManager.getGson().fromJson(wiredData,
+                    WiredConditionFurniTypeMatch.JsonData.class);
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (int id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -79,7 +80,7 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
             String[] data = set.getString("wired_data").split(";");
 
             for (String s : data) {
-                HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                 if (item != null) {
                     this.items.add(item);
@@ -107,10 +108,10 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -122,7 +123,8 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
     @Override
     public boolean saveData(WiredSettings settings) {
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 
@@ -145,7 +147,7 @@ public class WiredConditionNotFurniTypeMatch extends InteractionWiredCondition {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboCount.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboCount.java
@@ -80,7 +80,7 @@ public class WiredConditionNotHabboCount extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.lowerLimit);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboHasEffect.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboHasEffect.java
@@ -74,7 +74,7 @@ public class WiredConditionNotHabboHasEffect extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.effectId + "");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboWearsBadge.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboWearsBadge.java
@@ -88,7 +88,7 @@ public class WiredConditionNotHabboWearsBadge extends InteractionWiredCondition 
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.badge);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotInGroup.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotInGroup.java
@@ -68,7 +68,7 @@ public class WiredConditionNotInGroup extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotInTeam.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotInTeam.java
@@ -87,7 +87,7 @@ public class WiredConditionNotInTeam extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.teamColor.type);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamMember.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamMember.java
@@ -89,7 +89,7 @@ public class WiredConditionTeamMember extends InteractionWiredCondition {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.teamColor.type);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
@@ -28,7 +28,8 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
         super(set, baseItem);
     }
 
-    public WiredConditionTriggerOnFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredConditionTriggerOnFurni(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
     }
 
@@ -63,8 +64,7 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
     public String getWiredData() {
         this.refresh();
         return WiredManager.getGson().toJson(new JsonData(
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -75,8 +75,8 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (int id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item != null) {
                     this.items.add(item);
@@ -86,7 +86,7 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
             String[] data = wiredData.split(";");
 
             for (String s : data) {
-                HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                 if (item != null) {
                     this.items.add(item);
@@ -114,10 +114,10 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
         message.appendInt(this.items.size());
 
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -129,7 +129,8 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
     @Override
     public boolean saveData(WiredSettings settings) {
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count"))
+            return false;
 
         this.items.clear();
 

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotClothes.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotClothes.java
@@ -39,7 +39,7 @@ public class WiredEffectBotClothes extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName + ((char) 9) + "" + this.botLook);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotFollowHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotFollowHabbo.java
@@ -42,7 +42,7 @@ public class WiredEffectBotFollowHabbo extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName);
         message.appendInt(1);
         message.appendInt(this.mode);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotGiveHandItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotGiveHandItem.java
@@ -45,7 +45,7 @@ public class WiredEffectBotGiveHandItem extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName);
         message.appendInt(1);
         message.appendInt(this.itemId);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTalk.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTalk.java
@@ -41,7 +41,7 @@ public class WiredEffectBotTalk extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName + "" + ((char) 9) + "" + this.message);
         message.appendInt(1);
         message.appendInt(this.mode);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTalkToHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTalkToHabbo.java
@@ -44,7 +44,7 @@ public class WiredEffectBotTalkToHabbo extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName + "" + ((char) 9) + "" + this.message);
         message.appendInt(1);
         message.appendInt(this.mode);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTeleport.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTeleport.java
@@ -89,7 +89,7 @@ public class WiredEffectBotTeleport extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -101,10 +101,10 @@ public class WiredEffectBotTeleport extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName);
         message.appendInt(0);
         message.appendInt(0);
@@ -221,7 +221,7 @@ public class WiredEffectBotTeleport extends InteractionWiredEffect {
             this.botName = data.bot_name;
 
             for(int itemId : data.items) {
-                HabboItem item = room.getHabboItem(itemId);
+                HabboItem item = room.getHabboItemByDatabaseId(itemId);
 
                 if (item != null)
                     this.items.add(item);
@@ -238,7 +238,7 @@ public class WiredEffectBotTeleport extends InteractionWiredEffect {
                     this.botName = data[0];
 
                     for (int i = 1; i < data.length; i++) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(data[i]));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(data[i]));
 
                         if (item != null)
                             this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotWalkToFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotWalkToFurni.java
@@ -43,7 +43,7 @@ public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -55,10 +55,10 @@ public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName);
         message.appendInt(0);
         message.appendInt(0);
@@ -116,7 +116,7 @@ public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
         }
 
         Bot bot = bots.get(0);
-        this.items.removeIf(item -> item == null || item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null);
+        this.items.removeIf(item -> item == null || item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null);
 
         // Bots shouldn't walk to the tile they are already standing on
         List<HabboItem> possibleItems = this.items.stream()
@@ -168,7 +168,7 @@ public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
             this.botName = data.bot_name;
 
             for(int itemId : data.items) {
-                HabboItem item = room.getHabboItem(itemId);
+                HabboItem item = room.getHabboItemByDatabaseId(itemId);
 
                 if (item != null)
                     this.items.add(item);
@@ -185,7 +185,7 @@ public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
                     this.botName = data[0];
 
                     for (int i = 1; i < data.length; i++) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(data[i]));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(data[i]));
 
                         if (item != null)
                             this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectChangeFurniDirection.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectChangeFurniDirection.java
@@ -53,7 +53,7 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items.keySet()) {
-            if (item == null || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item == null || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -157,7 +157,7 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
             this.blockedAction = data.blocked_action;
 
             for(WiredChangeDirectionSetting setting : data.items) {
-                HabboItem item = room.getHabboItem(setting.item_id);
+                HabboItem item = room.getHabboItemByDatabaseId(setting.item_id);
 
                 if (item != null) {
                     this.items.put(item, setting);
@@ -179,7 +179,7 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
                         String[] subData = data[i].split(":");
 
                         if (subData.length >= 2) {
-                            HabboItem item = room.getHabboItem(Integer.parseInt(subData[0]));
+                            HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(subData[0]));
 
                             if (item != null) {
                                 int rotation = item.getRotation();
@@ -218,10 +218,10 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (Map.Entry<HabboItem, WiredChangeDirectionSetting> item : this.items.entrySet()) {
-            message.appendInt(item.getKey().getId());
+            message.appendInt(item.getKey().getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.startRotation != null ? this.startRotation.getValue() : 0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
@@ -40,7 +40,7 @@ public class WiredEffectGiveHotelviewBonusRarePoints extends InteractionWiredEff
         message.appendInt(0);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.amount + "");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
@@ -39,7 +39,7 @@ public class WiredEffectGiveHotelviewHofPoints extends InteractionWiredEffect {
         message.appendInt(0);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.amount + "");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
@@ -40,7 +40,7 @@ public class WiredEffectGiveRespect extends InteractionWiredEffect {
         message.appendInt(0);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.respects + "");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveReward.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveReward.java
@@ -151,7 +151,7 @@ public class WiredEffectGiveReward extends InteractionWiredEffect {
         message.appendInt(this.rewardItems.size());
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         StringBuilder s = new StringBuilder();
 
         for (WiredGiveRewardItem item : this.rewardItems) {

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveScore.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveScore.java
@@ -146,7 +146,7 @@ public class WiredEffectGiveScore extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.score);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveScoreToTeam.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveScoreToTeam.java
@@ -114,7 +114,7 @@ public class WiredEffectGiveScoreToTeam extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(3);
         message.appendInt(this.points);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectJoinTeam.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectJoinTeam.java
@@ -109,7 +109,7 @@ public class WiredEffectJoinTeam extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.teamColor.type);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectKickHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectKickHabbo.java
@@ -121,7 +121,7 @@ public class WiredEffectKickHabbo extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.message);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLeaveTeam.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLeaveTeam.java
@@ -94,7 +94,7 @@ public class WiredEffectLeaveTeam extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMatchFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMatchFurni.java
@@ -49,14 +49,14 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
     public void execute(WiredContext ctx) {
         Room room = ctx.room();
 
-        if(this.settings.isEmpty())
+        if (this.settings.isEmpty())
             return;
 
         if (room.getLayout() == null)
             return;
 
         for (WiredMatchFurniSetting setting : this.settings) {
-            HabboItem item = room.getHabboItem(setting.item_id);
+            HabboItem item = room.getHabboItemByDatabaseId(setting.item_id);
             if (item != null) {
                 if (this.state && (this.checkForWiredResetPermission && item.allowWiredResetState())) {
                     if (!setting.state.equals(" ") && !item.getExtradata().equals(setting.state)) {
@@ -66,23 +66,29 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
                 }
 
                 RoomTile oldLocation = room.getLayout().getTile(item.getX(), item.getY());
-                if (oldLocation == null) continue;
+                if (oldLocation == null)
+                    continue;
                 double oldZ = item.getZ();
 
-                if(this.direction && !this.position) {
-                    if(item.getRotation() != setting.rotation && room.furnitureFitsAt(oldLocation, item, setting.rotation, false) == FurnitureMovementError.NONE) {
+                if (this.direction && !this.position) {
+                    if (item.getRotation() != setting.rotation && room.furnitureFitsAt(oldLocation, item,
+                            setting.rotation, false) == FurnitureMovementError.NONE) {
                         room.moveFurniTo(item, oldLocation, setting.rotation, null, true);
                     }
-                }
-                else if(this.position) {
+                } else if (this.position) {
                     boolean slideAnimation = !this.direction || item.getRotation() == setting.rotation;
                     RoomTile newLocation = room.getLayout().getTile((short) setting.x, (short) setting.y);
                     int newRotation = this.direction ? setting.rotation : item.getRotation();
 
-                    if(newLocation != null && newLocation.state != RoomTileState.INVALID && (newLocation != oldLocation || newRotation != item.getRotation()) && room.furnitureFitsAt(newLocation, item, newRotation, true) == FurnitureMovementError.NONE) {
-                        if(room.moveFurniTo(item, newLocation, newRotation, null, !slideAnimation) == FurnitureMovementError.NONE) {
-                            if(slideAnimation) {
-                                room.sendComposer(new FloorItemOnRollerComposer(item, null, oldLocation, oldZ, newLocation, item.getZ(), 0, room).compose());
+                    if (newLocation != null && newLocation.state != RoomTileState.INVALID
+                            && (newLocation != oldLocation || newRotation != item.getRotation())
+                            && room.furnitureFitsAt(newLocation, item, newRotation,
+                                    true) == FurnitureMovementError.NONE) {
+                        if (room.moveFurniTo(item, newLocation, newRotation, null,
+                                !slideAnimation) == FurnitureMovementError.NONE) {
+                            if (slideAnimation) {
+                                room.sendComposer(new FloorItemOnRollerComposer(item, null, oldLocation, oldZ,
+                                        newLocation, item.getZ(), 0, room).compose());
                             }
                         }
                     }
@@ -101,14 +107,15 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
     @Override
     public String getWiredData() {
         this.refresh();
-        return WiredManager.getGson().toJson(new JsonData(this.state, this.direction, this.position, new ArrayList<WiredMatchFurniSetting>(this.settings), this.getDelay()));
+        return WiredManager.getGson().toJson(new JsonData(this.state, this.direction, this.position,
+                new ArrayList<WiredMatchFurniSetting>(this.settings), this.getDelay()));
     }
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
 
-        if(wiredData.startsWith("{")) {
+        if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.setDelay(data.delay);
             this.state = data.state;
@@ -116,8 +123,7 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
             this.position = data.position;
             this.settings.clear();
             this.settings.addAll(data.items);
-        }
-        else {
+        } else {
             String[] data = set.getString("wired_data").split(":");
 
             Integer.parseInt(data[0]); // itemCount - consumed but unused, data[1] contains actual items
@@ -130,7 +136,8 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
                     String[] stuff = items[i].split(Pattern.quote("-"));
 
                     if (stuff.length >= 5) {
-                        this.settings.add(new WiredMatchFurniSetting(Integer.parseInt(stuff[0]), stuff[1], Integer.parseInt(stuff[2]), Integer.parseInt(stuff[3]), Integer.parseInt(stuff[4])));
+                        this.settings.add(new WiredMatchFurniSetting(Integer.parseInt(stuff[0]), stuff[1],
+                                Integer.parseInt(stuff[2]), Integer.parseInt(stuff[3]), Integer.parseInt(stuff[4])));
                     }
 
                 } catch (Exception e) {
@@ -168,11 +175,13 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.settings.size());
 
-        for (WiredMatchFurniSetting item : this.settings)
-            message.appendInt(item.item_id);
+        for (WiredMatchFurniSetting setting : this.settings) {
+            HabboItem matchItem = room.getHabboItemByDatabaseId(setting.item_id);
+            message.appendInt(matchItem != null ? matchItem.getRoomVisibleId() : setting.item_id);
+        }
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(3);
         message.appendInt(this.state ? 1 : 0);
@@ -186,7 +195,8 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
-        if(settings.getIntParams().length < 3) throw new WiredSaveException("Invalid data");
+        if (settings.getIntParams().length < 3)
+            throw new WiredSaveException("Invalid data");
         boolean setState = settings.getIntParams()[0] == 1;
         boolean setDirection = settings.getIntParams()[1] == 1;
         boolean setPosition = settings.getIntParams()[2] == 1;
@@ -198,7 +208,7 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
 
         int itemsCount = settings.getFurniIds().length;
 
-        if(itemsCount > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+        if (itemsCount > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
             throw new WiredSaveException("Too many furni selected");
         }
 
@@ -208,15 +218,17 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
             int itemId = settings.getFurniIds()[i];
             HabboItem it = room.getHabboItem(itemId);
 
-            if(it == null)
+            if (it == null)
                 throw new WiredSaveException(String.format("Item %s not found", itemId));
 
-            newSettings.add(new WiredMatchFurniSetting(it.getId(), this.checkForWiredResetPermission && it.allowWiredResetState() ? it.getExtradata() : " ", it.getRotation(), it.getX(), it.getY()));
+            newSettings.add(new WiredMatchFurniSetting(it.getId(),
+                    this.checkForWiredResetPermission && it.allowWiredResetState() ? it.getExtradata() : " ",
+                    it.getRotation(), it.getX(), it.getY()));
         }
 
         int delay = settings.getDelay();
 
-        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
             throw new WiredSaveException("Delay too long");
 
         this.state = setState;
@@ -234,7 +246,7 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
 
         if (room != null && room.isLoaded()) {
             // Use removeIf for O(n) instead of O(n²) with separate remove set
-            this.settings.removeIf(setting -> room.getHabboItem(setting.item_id) == null);
+            this.settings.removeIf(setting -> room.getHabboItemByDatabaseId(setting.item_id) == null);
         }
     }
 
@@ -265,7 +277,8 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
         List<WiredMatchFurniSetting> items;
         int delay;
 
-        public JsonData(boolean state, boolean direction, boolean position, List<WiredMatchFurniSetting> items, int delay) {
+        public JsonData(boolean state, boolean direction, boolean position, List<WiredMatchFurniSetting> items,
+                int delay) {
             this.state = state;
             this.direction = direction;
             this.position = position;

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniAway.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniAway.java
@@ -173,7 +173,7 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.setDelay(data.delay);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -187,7 +187,7 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
             if (wiredDataOld.length == 2) {
                 if (wiredDataOld[1].contains(";")) {
                     for (String s : wiredDataOld[1].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);
@@ -213,7 +213,7 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -224,10 +224,10 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTo.java
@@ -51,7 +51,8 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
         this.items.clear();
         this.indexOffset.clear();
 
-        if(settings.getIntParams().length < 2) throw new WiredSaveException("invalid data");
+        if (settings.getIntParams().length < 2)
+            throw new WiredSaveException("invalid data");
         this.direction = settings.getIntParams()[0];
         this.spacing = settings.getIntParams()[1];
 
@@ -73,12 +74,14 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
     @Override
     public void execute(WiredContext ctx) {
         Room room = ctx.room();
-        if (room == null || room.getLayout() == null) return;
-        
+        if (room == null || room.getLayout() == null)
+            return;
+
         List<HabboItem> items = new ArrayList<>();
 
         for (HabboItem item : this.items) {
-            if (item == null || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item == null || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId())
+                    .getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -106,10 +109,14 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
                         RoomTile objectTile = room.getLayout().getTile(targetItem.getX(), targetItem.getY());
 
                         if (objectTile != null) {
-                            RoomTile sourceTile = room.getLayout().getTile(((HabboItem) object).getX(), ((HabboItem) object).getY());
-                            if (sourceTile == null) continue;
-                            
-                            THashSet<RoomTile> refreshTiles = room.getLayout().getTilesAt(sourceTile, ((HabboItem) object).getBaseItem().getWidth(), ((HabboItem) object).getBaseItem().getLength(), ((HabboItem) object).getRotation());
+                            RoomTile sourceTile = room.getLayout().getTile(((HabboItem) object).getX(),
+                                    ((HabboItem) object).getY());
+                            if (sourceTile == null)
+                                continue;
+
+                            THashSet<RoomTile> refreshTiles = room.getLayout().getTilesAt(sourceTile,
+                                    ((HabboItem) object).getBaseItem().getWidth(),
+                                    ((HabboItem) object).getBaseItem().getLength(), ((HabboItem) object).getRotation());
 
                             RoomTile tile = room.getLayout().getTileInFront(objectTile, this.direction, indexOffset);
                             if (tile == null || !tile.getAllowStack()) {
@@ -117,15 +124,20 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
                                 tile = room.getLayout().getTileInFront(objectTile, this.direction, indexOffset);
                             }
 
-                            if(tile == null) {
+                            if (tile == null) {
                                 continue;
                             }
 
-                            room.sendComposer(new FloorItemOnRollerComposer((HabboItem) object, null, tile, tile.getStackHeight() - ((HabboItem) object).getZ(), room).compose());
-                            
-                            RoomTile newSourceTile = room.getLayout().getTile(((HabboItem) object).getX(), ((HabboItem) object).getY());
+                            room.sendComposer(new FloorItemOnRollerComposer((HabboItem) object, null, tile,
+                                    tile.getStackHeight() - ((HabboItem) object).getZ(), room).compose());
+
+                            RoomTile newSourceTile = room.getLayout().getTile(((HabboItem) object).getX(),
+                                    ((HabboItem) object).getY());
                             if (newSourceTile != null) {
-                                refreshTiles.addAll(room.getLayout().getTilesAt(newSourceTile, ((HabboItem) object).getBaseItem().getWidth(), ((HabboItem) object).getBaseItem().getLength(), ((HabboItem) object).getRotation()));
+                                refreshTiles.addAll(room.getLayout().getTilesAt(newSourceTile,
+                                        ((HabboItem) object).getBaseItem().getWidth(),
+                                        ((HabboItem) object).getBaseItem().getLength(),
+                                        ((HabboItem) object).getRotation()));
                             }
                             room.updateTiles(refreshTiles);
                             this.indexOffset.put(targetItem.getId(), indexOffset);
@@ -145,26 +157,32 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
     @Override
     public boolean simulate(WiredContext ctx, WiredSimulation simulation) {
         Room room = ctx.room();
-        if (room == null || room.getLayout() == null) return true;
-        
+        if (room == null || room.getLayout() == null)
+            return true;
+
         Object[] stuff = ctx.legacySettings();
-        if (stuff == null || stuff.length == 0) return true;
-        
+        if (stuff == null || stuff.length == 0)
+            return true;
+
         for (Object object : stuff) {
             if (object instanceof HabboItem) {
                 HabboItem item = (HabboItem) object;
-                
-                if (this.items.isEmpty()) continue;
+
+                if (this.items.isEmpty())
+                    continue;
                 HabboItem targetItem = this.items.get(0);
-                if (targetItem == null) continue;
-                
+                if (targetItem == null)
+                    continue;
+
                 WiredSimulation.SimulatedPosition targetPos = simulation.getItemPosition(targetItem);
                 RoomTile objectTile = room.getLayout().getTile(targetPos.x, targetPos.y);
-                if (objectTile == null) continue;
-                
+                if (objectTile == null)
+                    continue;
+
                 RoomTile tile = room.getLayout().getTileInFront(objectTile, this.direction, 0);
-                if (tile == null) continue;
-                
+                if (tile == null)
+                    continue;
+
                 WiredSimulation.SimulatedPosition currentPos = simulation.getItemPosition(item);
                 if (!simulation.isTileValidForItem(tile.x, tile.y, item)) {
                     return false;
@@ -174,7 +192,7 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
                 }
             }
         }
-        
+
         return true;
     }
 
@@ -183,7 +201,8 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
         THashSet<HabboItem> itemsToRemove = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager()
+                    .getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 itemsToRemove.add(item);
         }
 
@@ -195,8 +214,7 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
                 this.direction,
                 this.spacing,
                 this.getDelay(),
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -204,7 +222,8 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager()
+                    .getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -216,9 +235,9 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.direction);
@@ -240,8 +259,8 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
             this.spacing = data.spacing;
             this.setDelay(data.delay);
 
-            for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (Integer id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -258,7 +277,7 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
                 }
 
                 for (String s : data[3].split("\r")) {
-                    HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                    HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                     if (item != null)
                         this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTowards.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTowards.java
@@ -93,7 +93,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -327,7 +327,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
             this.setDelay(data.delay);
 
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -341,7 +341,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
             if (wiredDataOld.length == 2) {
                 if (wiredDataOld[1].contains(";")) {
                     for (String s : wiredDataOld[1].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);
@@ -367,7 +367,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -378,10 +378,10 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveRotateFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveRotateFurni.java
@@ -30,7 +30,8 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
     private final Set<HabboItem> items = new LinkedHashSet<>(WiredManager.MAXIMUM_FURNI_SELECTION / 2);
     private int direction;
     private int rotation;
-    // Use thread-safe set for cooldowns since execute() can be called from async threads
+    // Use thread-safe set for cooldowns since execute() can be called from async
+    // threads
     private final Set<HabboItem> itemCooldowns = ConcurrentHashMap.newKeySet();
     // Pre-selected directions from simulation (itemId -> direction)
     private final Map<Integer, RoomUserRotation> preSelectedDirections = new ConcurrentHashMap<>();
@@ -39,7 +40,8 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
         super(set, baseItem);
     }
 
-    public WiredEffectMoveRotateFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredEffectMoveRotateFurni(int id, int userId, Item item, String extradata, int limitedStack,
+            int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
     }
 
@@ -47,10 +49,11 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
     public void execute(WiredContext ctx) {
         Room room = ctx.room();
         // remove items that are no longer in the room
-        this.items.removeIf(item -> Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null);
+        this.items.removeIf(item -> Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId())
+                .getHabboItemByDatabaseId(item.getId()) == null);
 
         for (HabboItem item : this.items) {
-            if(this.itemCooldowns.contains(item))
+            if (this.itemCooldowns.contains(item))
                 continue;
 
             int newRotation = this.rotation > 0 ? this.getNewRotation(item) : item.getRotation();
@@ -58,26 +61,46 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
             RoomTile oldLocation = room.getLayout().getTile(item.getX(), item.getY());
             double oldZ = item.getZ();
 
-            if(this.direction > 0) {
+            if (this.direction > 0) {
                 // Use pre-selected direction if available, otherwise pick random
                 RoomUserRotation moveDirection = this.preSelectedDirections.remove(item.getId());
                 if (moveDirection == null) {
                     moveDirection = this.getMovementDirection();
                 }
                 newLocation = room.getLayout().getTile(
-                    (short) (item.getX() + ((moveDirection == RoomUserRotation.WEST || moveDirection == RoomUserRotation.NORTH_WEST || moveDirection == RoomUserRotation.SOUTH_WEST) ? -1 : (((moveDirection == RoomUserRotation.EAST || moveDirection == RoomUserRotation.SOUTH_EAST || moveDirection == RoomUserRotation.NORTH_EAST) ? 1 : 0)))),
-                    (short) (item.getY() + ((moveDirection == RoomUserRotation.NORTH || moveDirection == RoomUserRotation.NORTH_EAST || moveDirection == RoomUserRotation.NORTH_WEST) ? 1 : ((moveDirection == RoomUserRotation.SOUTH || moveDirection == RoomUserRotation.SOUTH_EAST || moveDirection == RoomUserRotation.SOUTH_WEST) ? -1 : 0)))
-                );
+                        (short) (item.getX() + ((moveDirection == RoomUserRotation.WEST
+                                || moveDirection == RoomUserRotation.NORTH_WEST
+                                || moveDirection == RoomUserRotation.SOUTH_WEST)
+                                        ? -1
+                                        : (((moveDirection == RoomUserRotation.EAST
+                                                || moveDirection == RoomUserRotation.SOUTH_EAST
+                                                || moveDirection == RoomUserRotation.NORTH_EAST) ? 1 : 0)))),
+                        (short) (item.getY() + ((moveDirection == RoomUserRotation.NORTH
+                                || moveDirection == RoomUserRotation.NORTH_EAST
+                                || moveDirection == RoomUserRotation.NORTH_WEST)
+                                        ? 1
+                                        : ((moveDirection == RoomUserRotation.SOUTH
+                                                || moveDirection == RoomUserRotation.SOUTH_EAST
+                                                || moveDirection == RoomUserRotation.SOUTH_WEST) ? -1 : 0))));
             }
 
             boolean slideAnimation = item.getRotation() == newRotation;
 
             FurnitureMovementError furniMoveTest = room.furnitureFitsAt(newLocation, item, newRotation, true);
-            if(newLocation != null && newLocation.state != RoomTileState.INVALID && (newLocation != oldLocation || newRotation != item.getRotation()) && (furniMoveTest == FurnitureMovementError.NONE || ((furniMoveTest == FurnitureMovementError.TILE_HAS_BOTS || furniMoveTest == FurnitureMovementError.TILE_HAS_HABBOS || furniMoveTest == FurnitureMovementError.TILE_HAS_PETS) && newLocation == oldLocation))) {
-                if(room.furnitureFitsAt(newLocation, item, newRotation, false) == FurnitureMovementError.NONE && room.moveFurniTo(item, newLocation, newRotation, null, !slideAnimation) == FurnitureMovementError.NONE) {
+            if (newLocation != null && newLocation.state != RoomTileState.INVALID
+                    && (newLocation != oldLocation || newRotation != item.getRotation())
+                    && (furniMoveTest == FurnitureMovementError.NONE
+                            || ((furniMoveTest == FurnitureMovementError.TILE_HAS_BOTS
+                                    || furniMoveTest == FurnitureMovementError.TILE_HAS_HABBOS
+                                    || furniMoveTest == FurnitureMovementError.TILE_HAS_PETS)
+                                    && newLocation == oldLocation))) {
+                if (room.furnitureFitsAt(newLocation, item, newRotation, false) == FurnitureMovementError.NONE
+                        && room.moveFurniTo(item, newLocation, newRotation, null,
+                                !slideAnimation) == FurnitureMovementError.NONE) {
                     this.itemCooldowns.add(item);
-                    if(slideAnimation) {
-                        room.sendComposer(new FloorItemOnRollerComposer(item, null, oldLocation, oldZ, newLocation, item.getZ(), 0, room).compose());
+                    if (slideAnimation) {
+                        room.sendComposer(new FloorItemOnRollerComposer(item, null, oldLocation, oldZ, newLocation,
+                                item.getZ(), 0, room).compose());
                     }
                 }
             }
@@ -88,42 +111,53 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
     public boolean simulate(WiredContext ctx, WiredSimulation simulation) {
         // Clear any previous pre-selected directions
         this.preSelectedDirections.clear();
-        
+
         for (HabboItem item : this.items) {
-            if (item == null) continue;
-            
+            if (item == null)
+                continue;
+
             WiredSimulation.SimulatedPosition currentPos = simulation.getItemPosition(item);
             short newX = currentPos.x;
             short newY = currentPos.y;
-            
+
             if (this.direction > 0) {
                 // Pick the actual random direction now (same logic as getMovementDirection)
                 RoomUserRotation selectedDirection = this.getMovementDirection();
-                
+
                 // Calculate target position for the selected direction
-                short testX = (short) (currentPos.x + ((selectedDirection == RoomUserRotation.WEST || selectedDirection == RoomUserRotation.NORTH_WEST || selectedDirection == RoomUserRotation.SOUTH_WEST) ? -1 : 
-                    (((selectedDirection == RoomUserRotation.EAST || selectedDirection == RoomUserRotation.SOUTH_EAST || selectedDirection == RoomUserRotation.NORTH_EAST) ? 1 : 0))));
-                short testY = (short) (currentPos.y + ((selectedDirection == RoomUserRotation.NORTH || selectedDirection == RoomUserRotation.NORTH_EAST || selectedDirection == RoomUserRotation.NORTH_WEST) ? 1 : 
-                    ((selectedDirection == RoomUserRotation.SOUTH || selectedDirection == RoomUserRotation.SOUTH_EAST || selectedDirection == RoomUserRotation.SOUTH_WEST) ? -1 : 0)));
-                
+                short testX = (short) (currentPos.x + ((selectedDirection == RoomUserRotation.WEST
+                        || selectedDirection == RoomUserRotation.NORTH_WEST
+                        || selectedDirection == RoomUserRotation.SOUTH_WEST)
+                                ? -1
+                                : (((selectedDirection == RoomUserRotation.EAST
+                                        || selectedDirection == RoomUserRotation.SOUTH_EAST
+                                        || selectedDirection == RoomUserRotation.NORTH_EAST) ? 1 : 0))));
+                short testY = (short) (currentPos.y + ((selectedDirection == RoomUserRotation.NORTH
+                        || selectedDirection == RoomUserRotation.NORTH_EAST
+                        || selectedDirection == RoomUserRotation.NORTH_WEST)
+                                ? 1
+                                : ((selectedDirection == RoomUserRotation.SOUTH
+                                        || selectedDirection == RoomUserRotation.SOUTH_EAST
+                                        || selectedDirection == RoomUserRotation.SOUTH_WEST) ? -1 : 0)));
+
                 // Validate this specific direction
                 if (!simulation.isTileValidForItem(testX, testY, item)) {
                     return false; // This specific move would fail
                 }
-                
+
                 // Store the pre-selected direction for execution
                 this.preSelectedDirections.put(item.getId(), selectedDirection);
                 newX = testX;
                 newY = testY;
             }
-            
+
             if (newX != currentPos.x || newY != currentPos.y) {
                 if (!simulation.moveItem(item, newX, newY, currentPos.z, currentPos.rotation)) {
                     return false;
                 }
             }
         }
-        
+
         return true;
     }
 
@@ -134,7 +168,8 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || (room != null && room.getHabboItem(item.getId()) == null))
+            if (item.getRoomId() != this.getRoomId()
+                    || (room != null && room.getHabboItemByDatabaseId(item.getId()) == null))
                 itemsToRemove.add(item);
         }
 
@@ -146,8 +181,7 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
                 this.direction,
                 this.rotation,
                 this.getDelay(),
-                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())
-        ));
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList())));
     }
 
     @Override
@@ -160,8 +194,8 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
             this.setDelay(data.delay);
             this.direction = data.direction;
             this.rotation = data.rotation;
-            for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            for (Integer id : data.itemIds) {
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -179,7 +213,7 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
                 }
 
                 for (String s : data[3].split("\r")) {
-                    HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                    HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                     if (item != null)
                         this.items.add(item);
@@ -206,7 +240,8 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
         List<HabboItem> itemsToRemove = new ArrayList<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager()
+                    .getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 itemsToRemove.add(item);
         }
 
@@ -218,9 +253,9 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(2);
         message.appendInt(this.direction);
@@ -238,13 +273,15 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
         if (room == null)
             return false;
 
-        if(settings.getIntParams().length < 2) throw new WiredSaveException("invalid data");
+        if (settings.getIntParams().length < 2)
+            throw new WiredSaveException("invalid data");
 
         this.direction = settings.getIntParams()[0];
         this.rotation = settings.getIntParams()[1];
 
         int count = settings.getFurniIds().length;
-        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count", 5)) return false;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count", 5))
+            return false;
 
         this.items.clear();
         for (int i = 0; i < count; i++) {
@@ -259,7 +296,6 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
         return true;
     }
 
-
     /**
      * Returns a new rotation for an item based on the wired options
      *
@@ -267,27 +303,24 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
      * @return new rotation
      */
     private int getNewRotation(HabboItem item) {
-        if(item.getMaximumRotations() == 2) {
+        if (item.getMaximumRotations() == 2) {
             return item.getRotation() == 0 ? 4 : 0;
-        }
-        else if(item.getMaximumRotations() == 1) {
+        } else if (item.getMaximumRotations() == 1) {
             return item.getRotation();
-        }
-        else if(item.getMaximumRotations() > 4) {
+        } else if (item.getMaximumRotations() > 4) {
             if (this.rotation == 1) {
                 return item.getRotation() == item.getMaximumRotations() - 1 ? 0 : item.getRotation() + 1;
             } else if (this.rotation == 2) {
                 return item.getRotation() > 0 ? item.getRotation() - 1 : item.getMaximumRotations() - 1;
-            } else if (this.rotation == 3) { //Random rotation
+            } else if (this.rotation == 3) { // Random rotation
                 THashSet<Integer> possibleRotations = new THashSet<>();
-                for (int i = 0; i < item.getMaximumRotations(); i++)
-                {
+                for (int i = 0; i < item.getMaximumRotations(); i++) {
                     possibleRotations.add(i);
                 }
 
                 possibleRotations.remove(item.getRotation());
 
-                if(possibleRotations.size() > 0) {
+                if (possibleRotations.size() > 0) {
                     int index = Emulator.getRandom().nextInt(possibleRotations.size());
                     Iterator<Integer> iter = possibleRotations.iterator();
                     for (int i = 0; i < index; i++) {
@@ -296,26 +329,24 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
                     return iter.next();
                 }
             }
-        }
-        else {
+        } else {
             if (this.rotation == 1) {
                 return (item.getRotation() + 2) % 8;
             } else if (this.rotation == 2) {
                 int rot = (item.getRotation() - 2) % 8;
-                if(rot < 0) {
+                if (rot < 0) {
                     rot += 8;
                 }
                 return rot;
-            } else if (this.rotation == 3) { //Random rotation
+            } else if (this.rotation == 3) { // Random rotation
                 THashSet<Integer> possibleRotations = new THashSet<>();
-                for (int i = 0; i < item.getMaximumRotations(); i++)
-                {
+                for (int i = 0; i < item.getMaximumRotations(); i++) {
                     possibleRotations.add(i * 2);
                 }
 
                 possibleRotations.remove(item.getRotation());
 
-                if(possibleRotations.size() > 0) {
+                if (possibleRotations.size() > 0) {
                     int index = Emulator.getRandom().nextInt(possibleRotations.size());
                     Iterator<Integer> iter = possibleRotations.iterator();
                     for (int i = 0; i < index; i++) {
@@ -337,7 +368,8 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
     private RoomUserRotation getMovementDirection() {
         RoomUserRotation movemementDirection = RoomUserRotation.NORTH;
         if (this.direction == 1) {
-            movemementDirection = RoomUserRotation.values()[Emulator.getRandom().nextInt(RoomUserRotation.values().length / 2) * 2];
+            movemementDirection = RoomUserRotation
+                    .values()[Emulator.getRandom().nextInt(RoomUserRotation.values().length / 2) * 2];
         } else if (this.direction == 2) {
             if (Emulator.getRandom().nextInt(2) == 1) {
                 movemementDirection = RoomUserRotation.EAST;

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMuteHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMuteHabbo.java
@@ -40,7 +40,7 @@ public class WiredEffectMuteHabbo extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.message);
         message.appendInt(1);
         message.appendInt(this.length);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectResetTimers.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectResetTimers.java
@@ -39,7 +39,7 @@ public class WiredEffectResetTimers extends InteractionWiredEffect {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.getDelay());

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTeleport.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTeleport.java
@@ -116,7 +116,7 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -127,10 +127,10 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items)
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
 
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -198,7 +198,7 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
         }
         
         this.items.removeIf(item -> item == null || item.getRoomId() != this.getRoomId()
-                || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null);
+                || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null);
 
         if (!this.items.isEmpty()) {
             int i = Emulator.getRandom().nextInt(this.items.size());
@@ -236,7 +236,7 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.setDelay(data.delay);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -250,7 +250,7 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
             if (wiredDataOld.length == 2) {
                 if (wiredDataOld[1].contains(";")) {
                     for (String s : wiredDataOld[1].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleFurni.java
@@ -98,7 +98,7 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -110,10 +110,10 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -227,7 +227,7 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.setDelay(data.delay);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
 
                 if (item instanceof InteractionFreezeBlock || item instanceof InteractionFreezeTile || item instanceof InteractionCrackable) {
                     continue;
@@ -246,7 +246,7 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
             if (wiredDataOld.length == 2) {
                 if (wiredDataOld[1].contains(";")) {
                     for (String s : wiredDataOld[1].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item instanceof InteractionFreezeBlock || item instanceof InteractionFreezeTile || item instanceof InteractionCrackable)
                             continue;

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleRandom.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleRandom.java
@@ -95,7 +95,7 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -107,10 +107,10 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -212,7 +212,7 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.setDelay(data.delay);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 
                 if (item instanceof InteractionFreezeBlock || item instanceof InteractionGameTimer || item instanceof InteractionCrackable)
                     continue;
@@ -229,7 +229,7 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
             if (wiredDataOld.length == 2) {
                 if (wiredDataOld[1].contains(";")) {
                     for (String s : wiredDataOld[1].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item instanceof InteractionFreezeBlock || item instanceof InteractionGameTimer || item instanceof InteractionCrackable)
                             continue;

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTriggerStacks.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTriggerStacks.java
@@ -44,7 +44,7 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
         THashSet<HabboItem> items = new THashSet<>();
 
         for (HabboItem item : this.items) {
-            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                 items.add(item);
         }
 
@@ -55,10 +55,10 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -184,7 +184,7 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.setDelay(data.delay);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -198,7 +198,7 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
             if (wiredDataOld.length == 2) {
                 if (wiredDataOld[1].contains(";")) {
                     for (String s : wiredDataOld[1].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWhisper.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWhisper.java
@@ -41,7 +41,7 @@ public class WiredEffectWhisper extends InteractionWiredEffect {
         message.appendInt(0);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.message);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtSetTime.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtSetTime.java
@@ -104,7 +104,7 @@ public class WiredTriggerAtSetTime extends InteractionWiredTrigger implements Wi
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.executeTime / 500);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtTimeLong.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtTimeLong.java
@@ -104,7 +104,7 @@ public class WiredTriggerAtTimeLong extends InteractionWiredTrigger implements W
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.executeTime / 500);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerBotReachedFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerBotReachedFurni.java
@@ -54,7 +54,7 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+                if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }
@@ -67,10 +67,10 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName);
         message.appendInt(0);
         message.appendInt(0);
@@ -155,7 +155,7 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             this.botName = data.botName;
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -172,7 +172,7 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
 
                 for (String id : items) {
                     try {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(id));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(id));
 
                         if (item != null)
                             this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerBotReachedHabbo.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerBotReachedHabbo.java
@@ -38,7 +38,7 @@ public class WiredTriggerBotReachedHabbo extends InteractionWiredTrigger {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.botName);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerCollision.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerCollision.java
@@ -64,7 +64,7 @@ public class WiredTriggerCollision extends InteractionWiredTrigger {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerFurniStateToggled.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerFurniStateToggled.java
@@ -68,7 +68,7 @@ public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -79,7 +79,7 @@ public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
 
                 if (!wiredData.split(":")[2].equals("\t")) {
                     for (String s : wiredData.split(":")[2].split(";")) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                         if (item != null)
                             this.items.add(item);
@@ -109,7 +109,7 @@ public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
                 continue;
             }
 
-            if (room.getHabboItem(item.getId()) == null) {
+            if (room.getHabboItemByDatabaseId(item.getId()) == null) {
                 items.add(item);
             }
         }
@@ -122,10 +122,10 @@ public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameEnds.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameEnds.java
@@ -64,7 +64,7 @@ public class WiredTriggerGameEnds extends InteractionWiredTrigger {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameStarts.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameStarts.java
@@ -64,7 +64,7 @@ public class WiredTriggerGameStarts extends InteractionWiredTrigger {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboEntersRoom.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboEntersRoom.java
@@ -85,7 +85,7 @@ public class WiredTriggerHabboEntersRoom extends InteractionWiredTrigger {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.username);
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboSaysKeyword.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboSaysKeyword.java
@@ -92,7 +92,7 @@ public class WiredTriggerHabboSaysKeyword extends InteractionWiredTrigger {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString(this.key);
         message.appendInt(0);
         message.appendInt(1);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOffFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOffFurni.java
@@ -63,7 +63,7 @@ public class WiredTriggerHabboWalkOffFurni extends InteractionWiredTrigger {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -78,7 +78,7 @@ public class WiredTriggerHabboWalkOffFurni extends InteractionWiredTrigger {
                             continue;
 
                         try {
-                            HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                            HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                             if (item != null)
                                 this.items.add(item);
@@ -108,7 +108,7 @@ public class WiredTriggerHabboWalkOffFurni extends InteractionWiredTrigger {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (room.getHabboItem(item.getId()) == null)
+                if (room.getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }
@@ -121,10 +121,10 @@ public class WiredTriggerHabboWalkOffFurni extends InteractionWiredTrigger {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOnFurni.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOnFurni.java
@@ -61,7 +61,7 @@ public class WiredTriggerHabboWalkOnFurni extends InteractionWiredTrigger {
             items.addAll(this.items);
         } else {
             for (HabboItem item : this.items) {
-                if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+                if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItemByDatabaseId(item.getId()) == null)
                     items.add(item);
             }
         }
@@ -74,10 +74,10 @@ public class WiredTriggerHabboWalkOnFurni extends InteractionWiredTrigger {
         message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
         message.appendInt(this.items.size());
         for (HabboItem item : this.items) {
-            message.appendInt(item.getId());
+            message.appendInt(item.getRoomVisibleId());
         }
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(0);
         message.appendInt(0);
@@ -117,7 +117,7 @@ public class WiredTriggerHabboWalkOnFurni extends InteractionWiredTrigger {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
             for (Integer id: data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+                HabboItem item = room.getHabboItemByDatabaseId(id);
                 if (item != null) {
                     this.items.add(item);
                 }
@@ -132,7 +132,7 @@ public class WiredTriggerHabboWalkOnFurni extends InteractionWiredTrigger {
                             continue;
 
                         try {
-                            HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                            HabboItem item = room.getHabboItemByDatabaseId(Integer.parseInt(s));
 
                             if (item != null)
                                 this.items.add(item);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeater.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeater.java
@@ -93,7 +93,7 @@ public class WiredTriggerRepeater extends InteractionWiredTrigger implements Wir
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.repeatTime / 500);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterLong.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterLong.java
@@ -93,7 +93,7 @@ public class WiredTriggerRepeaterLong extends InteractionWiredTrigger implements
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.repeatTime / 5000);

--- a/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerScoreAchieved.java
+++ b/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerScoreAchieved.java
@@ -79,7 +79,7 @@ public class WiredTriggerScoreAchieved extends InteractionWiredTrigger {
         message.appendInt(5);
         message.appendInt(0);
         message.appendInt(this.getBaseItem().getSpriteId());
-        message.appendInt(this.getId());
+        message.appendInt(this.getRoomVisibleId());
         message.appendString("");
         message.appendInt(1);
         message.appendInt(this.score);

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -92,7 +92,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   public static final Comparator<Room> SORT_SCORE = (o1, o2) -> o2.getScore() - o1.getScore();
   public static final Comparator<Room> SORT_ID = (o1, o2) -> o2.getId() - o1.getId();
   private static final TIntObjectHashMap<RoomMoodlightData> defaultMoodData = new TIntObjectHashMap<>();
-  //Configuration. Loaded from database & updated accordingly.
+  // Configuration. Loaded from database & updated accordingly.
   public static boolean HABBO_CHAT_DELAY = false;
   public static int MAXIMUM_BOTS = 10;
   public static int MAXIMUM_PETS = 10;
@@ -123,7 +123,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private final Set<Game> games;
   private final TIntObjectMap<RoomMoodlightData> moodlightData;
   private final Object loadLock = new Object();
-  //Use appropriately. Could potentially cause memory leaks when used incorrectly.
+  // Use appropriately. Could potentially cause memory leaks when used
+  // incorrectly.
   public volatile boolean preventUnloading = false;
   public volatile boolean preventUncaching = false;
   public Set<ServerMessage> scheduledComposers = ConcurrentHashMap.newKeySet();
@@ -187,7 +188,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private volatile boolean muted;
   private RoomSpecialTypes roomSpecialTypes;
   private TraxManager traxManager;
-  
+
   public final THashMap<String, Object> cache;
 
   public Room(ResultSet set) throws SQLException {
@@ -235,8 +236,9 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.bannedHabbos = new TIntObjectHashMap<>();
 
     try (Connection connection = Emulator.getDatabase().getDataSource()
-        .getConnection(); PreparedStatement statement = connection.prepareStatement(
-        "SELECT * FROM room_promotions WHERE room_id = ? AND end_timestamp > ? LIMIT 1")) {
+        .getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            "SELECT * FROM room_promotions WHERE room_id = ? AND end_timestamp > ? LIMIT 1")) {
       if (this.promoted) {
         statement.setInt(1, this.id);
         statement.setInt(2, Emulator.getIntUnixTimestamp());
@@ -410,7 +412,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       if (this.loaded || this.loadingInProgress || !this.preLoaded) {
         return;
       }
-      
+
       this.loadingInProgress = true;
       this.loadingFuture = CompletableFuture.runAsync(() -> {
         this.loadDataInternal();
@@ -430,7 +432,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       }
       future = this.loadingFuture;
     }
-    
+
     if (future != null) {
       try {
         future.join();
@@ -445,7 +447,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   public void loadData() {
     CompletableFuture<Void> futureToWait = null;
     boolean shouldLoad = false;
-    
+
     synchronized (this.loadLock) {
       if (this.loadingInProgress) {
         // Get the future to wait on outside the lock
@@ -455,7 +457,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         shouldLoad = true;
       }
     }
-    
+
     // Wait for existing load outside the lock
     if (futureToWait != null) {
       try {
@@ -465,7 +467,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       }
       return;
     }
-    
+
     // Load if needed
     if (shouldLoad) {
       this.loadDataInternal();
@@ -526,21 +528,24 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         }
       }, Emulator.getThreading().getService());
 
-      // Wait for items to be loaded before loading wired data (wired depends on items)
+      // Wait for items to be loaded before loading wired data (wired depends on
+      // items)
       try {
         itemsFuture.join();
       } catch (Exception e) {
         LOGGER.error("Error waiting for items to load", e);
       }
 
-      // Phase 3: Load heightmap after items are loaded (depends on items for stack heights)
+      // Phase 3: Load heightmap after items are loaded (depends on items for stack
+      // heights)
       try {
         this.loadHeightmap();
       } catch (Exception e) {
         LOGGER.error("Caught exception loading heightmap", e);
       }
 
-      // Phase 4: Load bots, pets, and wired data in parallel (all depend on layout + items)
+      // Phase 4: Load bots, pets, and wired data in parallel (all depend on layout +
+      // items)
       CompletableFuture<Void> botsFuture = CompletableFuture.runAsync(() -> {
         try (Connection botsConnection = Emulator.getDatabase().getDataSource().getConnection()) {
           this.loadBots(botsConnection);
@@ -598,7 +603,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       item.setExtradata("1");
       this.updateItem(item);
     }
-    
+
     // Set loaded flag with lock
     synchronized (this.loadLock) {
       this.loaded = true;
@@ -670,7 +675,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
             }
             b.getRoomUnit().setRoomUnitType(RoomUnitType.BOT);
             b.getRoomUnit().setDanceType(DanceType.values()[set.getInt("dance")]);
-            //b.getRoomUnit().setCanWalk(set.getBoolean("freeroam"));
+            // b.getRoomUnit().setCanWalk(set.getBoolean("freeroam"));
             b.getRoomUnit().setInRoom(true);
             this.giveEffect(b.getRoomUnit(), set.getInt("effect"), Integer.MAX_VALUE);
             this.addBot(b);
@@ -892,7 +897,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       if (this.loaded) {
         // Set loaded to false FIRST to prevent re-entry and ensure cycle stops
         this.loaded = false;
-        
+
         try {
           if (this.traxManager != null && !this.traxManager.disposed()) {
             this.traxManager.dispose();
@@ -927,10 +932,10 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
           if (this.roomSpecialTypes != null) {
             this.roomSpecialTypes.dispose();
           }
-          
+
           // Unregister all wired tickables for this room from the tick service
           com.eu.habbo.habbohotel.wired.core.WiredManager.unregisterRoomTickables(this);
-          
+
           // Clear wired engine caches for this room
           if (com.eu.habbo.habbohotel.wired.core.WiredManager.getStackIndex() != null) {
             com.eu.habbo.habbohotel.wired.core.WiredManager.getStackIndex().invalidateAll(this);
@@ -953,11 +958,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
           // Save bots BEFORE clearing - must happen before unitManager.clear()
           TIntObjectIterator<Bot> botIterator = this.getCurrentBots().iterator();
 
-          for (int i = this.getCurrentBots().size(); i-- > 0; ) {
+          for (int i = this.getCurrentBots().size(); i-- > 0;) {
             try {
               botIterator.advance();
               botIterator.value().needsUpdate(true);
-              botIterator.value().run();  // Run synchronously to ensure DB is updated before room reload
+              botIterator.value().run(); // Run synchronously to ensure DB is updated before room reload
             } catch (NoSuchElementException e) {
               LOGGER.error("Caught exception", e);
               break;
@@ -966,11 +971,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
           // Save ALL remaining pets (including owner's pets) BEFORE clearing
           TIntObjectIterator<Pet> petIterator = this.getCurrentPets().iterator();
-          for (int i = this.getCurrentPets().size(); i-- > 0; ) {
+          for (int i = this.getCurrentPets().size(); i-- > 0;) {
             try {
               petIterator.advance();
               petIterator.value().needsUpdate = true;
-              petIterator.value().run();  // Run synchronously to ensure DB is updated before room reload
+              petIterator.value().run(); // Run synchronously to ensure DB is updated before room reload
             } catch (NoSuchElementException e) {
               LOGGER.error("Caught exception", e);
               break;
@@ -1095,8 +1100,9 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   public void save() {
     if (this.needsUpdate) {
       try (Connection connection = Emulator.getDatabase().getDataSource()
-          .getConnection(); PreparedStatement statement = connection.prepareStatement(
-          "UPDATE rooms SET name = ?, description = ?, password = ?, state = ?, users_max = ?, category = ?, score = ?, paper_floor = ?, paper_wall = ?, paper_landscape = ?, thickness_wall = ?, wall_height = ?, thickness_floor = ?, moodlight_data = ?, tags = ?, allow_other_pets = ?, allow_other_pets_eat = ?, allow_walkthrough = ?, allow_hidewall = ?, chat_mode = ?, chat_weight = ?, chat_speed = ?, chat_hearing_distance = ?, chat_protection =?, who_can_mute = ?, who_can_kick = ?, who_can_ban = ?, poll_id = ?, guild_id = ?, roller_speed = ?, override_model = ?, is_staff_picked = ?, promoted = ?, trade_mode = ?, move_diagonally = ?, owner_id = ?, owner_name = ?, jukebox_active = ?, hidewired = ? WHERE id = ?")) {
+          .getConnection();
+          PreparedStatement statement = connection.prepareStatement(
+              "UPDATE rooms SET name = ?, description = ?, password = ?, state = ?, users_max = ?, category = ?, score = ?, paper_floor = ?, paper_wall = ?, paper_landscape = ?, thickness_wall = ?, wall_height = ?, thickness_floor = ?, moodlight_data = ?, tags = ?, allow_other_pets = ?, allow_other_pets_eat = ?, allow_walkthrough = ?, allow_hidewall = ?, chat_mode = ?, chat_weight = ?, chat_speed = ?, chat_hearing_distance = ?, chat_protection =?, who_can_mute = ?, who_can_kick = ?, who_can_ban = ?, poll_id = ?, guild_id = ?, roller_speed = ?, override_model = ?, is_staff_picked = ?, promoted = ?, trade_mode = ?, move_diagonally = ?, owner_id = ?, owner_name = ?, jukebox_active = ?, hidewired = ? WHERE id = ?")) {
         statement.setString(1, this.name);
         statement.setString(2, this.description);
         statement.setString(3, this.password);
@@ -1160,8 +1166,9 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
    */
   public void updateDatabaseUserCount() {
     try (Connection connection = Emulator.getDatabase().getDataSource()
-        .getConnection(); PreparedStatement statement = connection.prepareStatement(
-        "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1")) {
+        .getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1")) {
       statement.setInt(1, this.getUserCount());
       statement.setInt(2, this.id);
       statement.executeUpdate();
@@ -1573,8 +1580,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public String[] filterAnything() {
-    return new String[]{this.getOwnerName(), this.getGuildName(), this.getDescription(),
-        this.getPromotionDesc()};
+    return new String[] { this.getOwnerName(), this.getGuildName(), this.getDescription(),
+        this.getPromotionDesc() };
   }
 
   public long getCycleTimestamp() {
@@ -1733,13 +1740,16 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public HabboItem getHabboItem(int id) {
+    return this.itemManager.getHabboItemByVisibleId(id);
+  }
+
+  public HabboItem getHabboItemByDatabaseId(int id) {
     return this.itemManager.getHabboItem(id);
   }
 
   void removeHabboItem(int id) {
     this.itemManager.removeHabboItem(id);
   }
-
 
   public void removeHabboItem(HabboItem item) {
     this.itemManager.removeHabboItem(item);
@@ -2094,7 +2104,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   /**
-   * @deprecated Deprecated since 2.5.0. Use {@link #getGuildRightLevel(Habbo)} instead.
+   * @deprecated Deprecated since 2.5.0. Use {@link #getGuildRightLevel(Habbo)}
+   *             instead.
    */
   @Deprecated
   public int guildRightLevel(Habbo habbo) {
@@ -2272,11 +2283,9 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.itemManager.ejectUserItem(item);
   }
 
-
   public void ejectAll() {
     this.itemManager.ejectAll();
   }
-
 
   public void ejectAll(Habbo habbo) {
     this.itemManager.ejectAll(habbo);
@@ -2308,7 +2317,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       TIntObjectMap<HabboItem> items = this.itemManager.getRoomItems();
       TIntObjectIterator<HabboItem> iterator = items.iterator();
 
-      for (int i = items.size(); i-- > 0; ) {
+      for (int i = items.size(); i-- > 0;) {
         try {
           iterator.advance();
         } catch (Exception e) {

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -2256,6 +2256,18 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.itemManager.ejectUserFurni(userId);
   }
 
+  public void pickUpBuildersClubItems(int userId, Habbo picker) {
+    this.itemManager.pickUpBuildersClubItems(userId, picker);
+  }
+
+  public void pickUpBuildersClubItem(HabboItem item, Habbo picker) {
+    this.itemManager.pickUpBuildersClubItem(item, picker);
+  }
+
+  public boolean hasBuildersClubItems() {
+    return this.itemManager.hasBuildersClubItems();
+  }
+
   public void ejectUserItem(HabboItem item) {
     this.itemManager.ejectUserItem(item);
   }

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -2279,6 +2279,10 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.itemManager.hasBuildersClubItems();
   }
 
+  public boolean hasUserBuildersClubItems(int userId) {
+    return this.itemManager.hasUserBuildersClubItems(userId);
+  }
+
   public void ejectUserItem(HabboItem item) {
     this.itemManager.ejectUserItem(item);
   }

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -36,7 +36,7 @@ import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.outgoing.rooms.items.ObjectAddMessageComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemAddMessageComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.FloorItemOnRollerComposer;
-import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
+
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.furniture.FurnitureBuildheightEvent;
 import com.eu.habbo.plugin.events.furniture.FurnitureMovedEvent;
@@ -61,6 +61,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Manages all items/furniture within a room.
@@ -81,6 +86,12 @@ public class RoomItemManager {
     // Tile cache for item lookups
     public final ConcurrentHashMap<RoomTile, THashSet<HabboItem>> tileCache;
 
+    // Builder's Club virtual ID mapping
+    private static final int BC_VISIBLE_ID_BASE = 0x7FFF0000;
+    private final ConcurrentHashMap<Integer, Integer> bcVisibleIdByRealId = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, Integer> bcRealIdByVisibleId = new ConcurrentHashMap<>();
+    private final AtomicInteger nextBcOrdinal = new AtomicInteger(0);
+
     public RoomItemManager(Room room) {
         this.room = room;
         this.roomItems = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
@@ -99,8 +110,13 @@ public class RoomItemManager {
             this.roomItems.clear();
         }
 
+        // Clear BC maps before loading
+        this.bcVisibleIdByRealId.clear();
+        this.bcRealIdByVisibleId.clear();
+        this.nextBcOrdinal.set(0);
+
         try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT * FROM items WHERE room_id = ?")) {
+                "SELECT * FROM items WHERE room_id = ?")) {
             statement.setInt(1, this.room.getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -111,9 +127,33 @@ public class RoomItemManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
+        // Rebuild BC visible ID mappings sorted by real ID ASC
+        List<HabboItem> bcItems = new ArrayList<>();
+        synchronized (this.roomItems) {
+            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
+            for (int i = this.roomItems.size(); i-- > 0;) {
+                try {
+                    iterator.advance();
+                } catch (Exception e) {
+                    break;
+                }
+                if (iterator.value().isBuildersClub()) {
+                    bcItems.add(iterator.value());
+                }
+            }
+        }
+        bcItems.sort(Comparator.comparingInt(HabboItem::getId));
+        // Reset ordinal and rebuild maps in sorted order
+        this.bcVisibleIdByRealId.clear();
+        this.bcRealIdByVisibleId.clear();
+        this.nextBcOrdinal.set(0);
+        for (HabboItem bcItem : bcItems) {
+            this.assignBcVisibleId(bcItem);
+        }
+
         if (this.itemCount() > Room.MAXIMUM_FURNI) {
-            LOGGER.error("Room ID: {} has exceeded the furniture limit ({} > {}).", 
-                this.room.getId(), this.itemCount(), Room.MAXIMUM_FURNI);
+            LOGGER.error("Room ID: {} has exceeded the furniture limit ({} > {}).",
+                    this.room.getId(), this.itemCount(), Room.MAXIMUM_FURNI);
         }
     }
 
@@ -122,7 +162,7 @@ public class RoomItemManager {
      */
     public void loadWiredData(Connection connection) {
         try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT id, wired_data FROM items WHERE room_id = ? AND wired_data<>''")) {
+                "SELECT id, wired_data FROM items WHERE room_id = ? AND wired_data<>''")) {
             statement.setInt(1, this.room.getId());
 
             try (ResultSet set = statement.executeQuery()) {
@@ -143,6 +183,47 @@ public class RoomItemManager {
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
         }
+    }
+
+    /**
+     * Assigns a room-local BC virtual ID to an item.
+     */
+    public void assignBcVisibleId(HabboItem item) {
+        int ordinal = this.nextBcOrdinal.getAndIncrement();
+        int visibleId = BC_VISIBLE_ID_BASE + ordinal;
+        this.bcVisibleIdByRealId.put(item.getId(), visibleId);
+        this.bcRealIdByVisibleId.put(visibleId, item.getId());
+        item.setRoomVisibleId(visibleId);
+    }
+
+    /**
+     * Removes a BC virtual ID mapping for an item.
+     */
+    public void removeBcVisibleId(HabboItem item) {
+        Integer visibleId = this.bcVisibleIdByRealId.remove(item.getId());
+        if (visibleId != null) {
+            this.bcRealIdByVisibleId.remove(visibleId);
+        }
+        item.clearRoomVisibleId();
+    }
+
+    /**
+     * Resolves a visible ID to a real DB ID.
+     */
+    public int resolveVisibleId(int visibleId) {
+        if (visibleId >= BC_VISIBLE_ID_BASE) {
+            Integer realId = this.bcRealIdByVisibleId.get(visibleId);
+            return realId != null ? realId : visibleId;
+        }
+        return visibleId;
+    }
+
+    /**
+     * Gets an item by its client-visible ID.
+     */
+    public HabboItem getHabboItemByVisibleId(int visibleId) {
+        int realId = this.resolveVisibleId(visibleId);
+        return this.getHabboItem(realId);
     }
 
     // ==================== ITEM RETRIEVAL ====================
@@ -228,7 +309,7 @@ public class RoomItemManager {
         THashSet<HabboItem> items = new THashSet<>();
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
+        for (int i = this.roomItems.size(); i-- > 0;) {
             try {
                 iterator.advance();
             } catch (Exception e) {
@@ -250,7 +331,7 @@ public class RoomItemManager {
         THashSet<HabboItem> items = new THashSet<>();
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
+        for (int i = this.roomItems.size(); i-- > 0;) {
             try {
                 iterator.advance();
             } catch (Exception e) {
@@ -272,15 +353,14 @@ public class RoomItemManager {
         THashSet<HabboItem> items = new THashSet<>();
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
+        for (int i = this.roomItems.size(); i-- > 0;) {
             try {
                 iterator.advance();
             } catch (Exception e) {
                 break;
             }
 
-            if (iterator.value().getBaseItem().getInteractionType().getType()
-                == InteractionPostIt.class) {
+            if (iterator.value().getBaseItem().getInteractionType().getType() == InteractionPostIt.class) {
                 items.add(iterator.value());
             }
         }
@@ -337,7 +417,7 @@ public class RoomItemManager {
 
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
+        for (int i = this.roomItems.size(); i-- > 0;) {
             HabboItem item;
             try {
                 iterator.advance();
@@ -365,7 +445,7 @@ public class RoomItemManager {
             }
 
             if (!(tile.x >= item.getX() && tile.x <= item.getX() + width - 1 && tile.y >= item.getY()
-                && tile.y <= item.getY() + length - 1)) {
+                    && tile.y <= item.getY() + length - 1)) {
                 continue;
             }
 
@@ -452,8 +532,8 @@ public class RoomItemManager {
                 continue;
             }
 
-            if (highestItem != null && highestItem.getZ() + Item.getCurrentHeight(highestItem)
-                > item.getZ() + Item.getCurrentHeight(item)) {
+            if (highestItem != null && highestItem.getZ() + Item.getCurrentHeight(highestItem) > item.getZ()
+                    + Item.getCurrentHeight(item)) {
                 continue;
             }
 
@@ -479,8 +559,8 @@ public class RoomItemManager {
                     continue;
                 }
 
-                if (highestItem != null && highestItem.getZ() + Item.getCurrentHeight(highestItem)
-                    > item.getZ() + Item.getCurrentHeight(item)) {
+                if (highestItem != null && highestItem.getZ() + Item.getCurrentHeight(highestItem) > item.getZ()
+                        + Item.getCurrentHeight(item)) {
                     continue;
                 }
 
@@ -561,8 +641,8 @@ public class RoomItemManager {
                     continue;
                 }
 
-                if (lowestChair != null && lowestChair.getZ() + Item.getCurrentHeight(lowestChair)
-                    > item.getZ() + Item.getCurrentHeight(item)) {
+                if (lowestChair != null && lowestChair.getZ() + Item.getCurrentHeight(lowestChair) > item.getZ()
+                        + Item.getCurrentHeight(item)) {
                     continue;
                 }
 
@@ -602,14 +682,19 @@ public class RoomItemManager {
                 if (habbo != null) {
                     this.furniOwnerNames.put(item.getUserId(), habbo.getUsername());
                 } else {
-                    LOGGER.error("Failed to find username for item (ID: {}, UserID: {})", 
-                        item.getId(), item.getUserId());
+                    LOGGER.error("Failed to find username for item (ID: {}, UserID: {})",
+                            item.getId(), item.getUserId());
                 }
             }
         }
 
         // Register with special types
         this.registerItemWithSpecialTypes(item);
+
+        // Assign BC visible ID if this is a Builder's Club item
+        if (item.isBuildersClub()) {
+            this.assignBcVisibleId(item);
+        }
     }
 
     /**
@@ -620,11 +705,12 @@ public class RoomItemManager {
         if (specialTypes == null) {
             return;
         }
-        
+
         boolean isWiredItem = false;
 
         synchronized (specialTypes) {
-            // Register with tick service for time-based wired triggers (new 50ms tick system)
+            // Register with tick service for time-based wired triggers (new 50ms tick
+            // system)
             // This replaces ICycleable for wired items
             if (item instanceof WiredTickable) {
                 WiredManager.registerTickable(this.room, (WiredTickable) item);
@@ -669,29 +755,29 @@ public class RoomItemManager {
             } else if (item instanceof InteractionPetTree) {
                 specialTypes.addPetTree((InteractionPetTree) item);
             } else if (item instanceof InteractionMoodLight ||
-                       item instanceof InteractionPyramid ||
-                       item instanceof InteractionMusicDisc ||
-                       item instanceof InteractionBattleBanzaiSphere ||
-                       item instanceof InteractionTalkingFurniture ||
-                       item instanceof InteractionWater ||
-                       item instanceof InteractionWaterItem ||
-                       item instanceof InteractionMuteArea ||
-                       item instanceof InteractionBuildArea ||
-                       item instanceof InteractionTagPole ||
-                       item instanceof InteractionTagField ||
-                       item instanceof InteractionJukeBox ||
-                       item instanceof InteractionPetBreedingNest ||
-                       item instanceof InteractionBlackHole ||
-                       item instanceof InteractionWiredHighscore ||
-                       item instanceof InteractionStickyPole ||
-                       item instanceof WiredBlob ||
-                       item instanceof InteractionTent ||
-                       item instanceof InteractionSnowboardSlope ||
-                       item instanceof InteractionFireworks) {
+                    item instanceof InteractionPyramid ||
+                    item instanceof InteractionMusicDisc ||
+                    item instanceof InteractionBattleBanzaiSphere ||
+                    item instanceof InteractionTalkingFurniture ||
+                    item instanceof InteractionWater ||
+                    item instanceof InteractionWaterItem ||
+                    item instanceof InteractionMuteArea ||
+                    item instanceof InteractionBuildArea ||
+                    item instanceof InteractionTagPole ||
+                    item instanceof InteractionTagField ||
+                    item instanceof InteractionJukeBox ||
+                    item instanceof InteractionPetBreedingNest ||
+                    item instanceof InteractionBlackHole ||
+                    item instanceof InteractionWiredHighscore ||
+                    item instanceof InteractionStickyPole ||
+                    item instanceof WiredBlob ||
+                    item instanceof InteractionTent ||
+                    item instanceof InteractionSnowboardSlope ||
+                    item instanceof InteractionFireworks) {
                 specialTypes.addUndefined(item);
             }
         }
-        
+
         // Invalidate wired cache when wired items are added
         if (isWiredItem) {
             WiredManager.invalidateRoom(this.room);
@@ -711,6 +797,11 @@ public class RoomItemManager {
     public void removeHabboItem(HabboItem item) {
         if (item == null) {
             return;
+        }
+
+        // Remove BC visible ID mapping if this is a Builder's Club item
+        if (item.isBuildersClub()) {
+            this.removeBcVisibleId(item);
         }
 
         HabboItem i;
@@ -745,10 +836,11 @@ public class RoomItemManager {
         if (specialTypes == null) {
             return;
         }
-        
+
         boolean isWiredItem = false;
 
-        // Unregister from tick service for time-based wired triggers (new 50ms tick system)
+        // Unregister from tick service for time-based wired triggers (new 50ms tick
+        // system)
         if (item instanceof WiredTickable) {
             WiredManager.unregisterTickable(this.room, (WiredTickable) item);
         }
@@ -792,26 +884,26 @@ public class RoomItemManager {
         } else if (item instanceof InteractionPetTree) {
             specialTypes.removePetTree((InteractionPetTree) item);
         } else if (item instanceof InteractionMoodLight ||
-                   item instanceof InteractionPyramid ||
-                   item instanceof InteractionMusicDisc ||
-                   item instanceof InteractionBattleBanzaiSphere ||
-                   item instanceof InteractionTalkingFurniture ||
-                   item instanceof InteractionWaterItem ||
-                   item instanceof InteractionWater ||
-                   item instanceof InteractionMuteArea ||
-                   item instanceof InteractionTagPole ||
-                   item instanceof InteractionTagField ||
-                   item instanceof InteractionJukeBox ||
-                   item instanceof InteractionPetBreedingNest ||
-                   item instanceof InteractionBlackHole ||
-                   item instanceof InteractionWiredHighscore ||
-                   item instanceof InteractionStickyPole ||
-                   item instanceof WiredBlob ||
-                   item instanceof InteractionTent ||
-                   item instanceof InteractionSnowboardSlope) {
+                item instanceof InteractionPyramid ||
+                item instanceof InteractionMusicDisc ||
+                item instanceof InteractionBattleBanzaiSphere ||
+                item instanceof InteractionTalkingFurniture ||
+                item instanceof InteractionWaterItem ||
+                item instanceof InteractionWater ||
+                item instanceof InteractionMuteArea ||
+                item instanceof InteractionTagPole ||
+                item instanceof InteractionTagField ||
+                item instanceof InteractionJukeBox ||
+                item instanceof InteractionPetBreedingNest ||
+                item instanceof InteractionBlackHole ||
+                item instanceof InteractionWiredHighscore ||
+                item instanceof InteractionStickyPole ||
+                item instanceof WiredBlob ||
+                item instanceof InteractionTent ||
+                item instanceof InteractionSnowboardSlope) {
             specialTypes.removeUndefined(item);
         }
-        
+
         // Invalidate wired cache when wired items are removed
         if (isWiredItem) {
             WiredManager.invalidateRoom(this.room);
@@ -830,9 +922,9 @@ public class RoomItemManager {
                     if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
                         this.room.sendComposer(new ObjectUpdateMessageComposer(item).compose());
                         this.room.updateTiles(this.room.getLayout()
-                            .getTilesAt(this.room.getLayout().getTile(item.getX(), item.getY()),
-                                item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
-                                item.getRotation()));
+                                .getTilesAt(this.room.getLayout().getTile(item.getX(), item.getY()),
+                                        item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
+                                        item.getRotation()));
                     } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
                         this.room.sendComposer(new ItemUpdateMessageComposer(item).compose());
                     }
@@ -857,9 +949,9 @@ public class RoomItemManager {
             }
 
             this.room.updateTiles(this.room.getLayout()
-                .getTilesAt(this.room.getLayout().getTile(item.getX(), item.getY()),
-                    item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
-                    item.getRotation()));
+                    .getTilesAt(this.room.getLayout().getTile(item.getX(), item.getY()),
+                            item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
+                            item.getRotation()));
 
             if (item instanceof InteractionMultiHeight) {
                 ((InteractionMultiHeight) item).updateUnitsOnItem(this.room);
@@ -924,11 +1016,18 @@ public class RoomItemManager {
 
         if (Emulator.getPluginManager().isRegistered(FurniturePickedUpEvent.class, true)) {
             FurniturePickedUpEvent event = Emulator.getPluginManager()
-                .fireEvent(new FurniturePickedUpEvent(item, picker));
+                    .fireEvent(new FurniturePickedUpEvent(item, picker));
 
             if (event.isCancelled()) {
                 return;
             }
+        }
+
+        // Send removal packet BEFORE removing from room, so visible ID is still valid
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            this.room.sendComposer(new ObjectRemoveMessageComposer(item).compose());
+        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
+            this.room.sendComposer(new ItemRemoveMessageComposer(item).compose());
         }
 
         this.removeHabboItem(item);
@@ -937,45 +1036,6 @@ public class RoomItemManager {
         item.needsUpdate(true);
 
         if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-            this.room.sendComposer(new ObjectRemoveMessageComposer(item).compose());
-
-            THashSet<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
-                this.room.getLayout().getTile(item.getX(), item.getY()),
-                item.getBaseItem().getWidth(),
-                item.getBaseItem().getLength(),
-                item.getRotation());
-            this.room.updateTiles(updatedTiles);
-
-            for (RoomTile tile : updatedTiles) {
-                this.room.updateHabbosAt(tile.x, tile.y);
-                this.room.updateBotsAt(tile.x, tile.y);
-            }
-        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
-            this.room.sendComposer(new ItemRemoveMessageComposer(item).compose());
-        }
-
-        Emulator.getThreading().run(item);
-    }
-
-    public void pickUpBuildersClubItem(HabboItem item, Habbo picker) {
-        if (item == null || !SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
-            return;
-        }
-
-        if (Emulator.getPluginManager().isRegistered(FurniturePickedUpEvent.class, true)) {
-            FurniturePickedUpEvent event = Emulator.getPluginManager().fireEvent(new FurniturePickedUpEvent(item, picker));
-
-            if (event.isCancelled()) {
-                return;
-            }
-        }
-
-        this.removeHabboItem(item);
-        item.onPickUp(this.room);
-
-        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-            this.room.sendComposer(new ObjectRemoveMessageComposer(item).compose());
-
             THashSet<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
                     this.room.getLayout().getTile(item.getX(), item.getY()),
                     item.getBaseItem().getWidth(),
@@ -987,8 +1047,47 @@ public class RoomItemManager {
                 this.room.updateHabbosAt(tile.x, tile.y);
                 this.room.updateBotsAt(tile.x, tile.y);
             }
+        }
+
+        Emulator.getThreading().run(item);
+    }
+
+    public void pickUpBuildersClubItem(HabboItem item, Habbo picker) {
+        if (item == null || !item.isBuildersClub()) {
+            return;
+        }
+
+        if (Emulator.getPluginManager().isRegistered(FurniturePickedUpEvent.class, true)) {
+            FurniturePickedUpEvent event = Emulator.getPluginManager()
+                    .fireEvent(new FurniturePickedUpEvent(item, picker));
+
+            if (event.isCancelled()) {
+                return;
+            }
+        }
+
+        // Send removal packet BEFORE removing from room, so visible ID is still valid
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            this.room.sendComposer(new ObjectRemoveMessageComposer(item).compose());
         } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
             this.room.sendComposer(new ItemRemoveMessageComposer(item).compose());
+        }
+
+        this.removeHabboItem(item);
+        item.onPickUp(this.room);
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            THashSet<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
+                    this.room.getLayout().getTile(item.getX(), item.getY()),
+                    item.getBaseItem().getWidth(),
+                    item.getBaseItem().getLength(),
+                    item.getRotation());
+            this.room.updateTiles(updatedTiles);
+
+            for (RoomTile tile : updatedTiles) {
+                this.room.updateHabbosAt(tile.x, tile.y);
+                this.room.updateBotsAt(tile.x, tile.y);
+            }
         }
 
         Emulator.getGameEnvironment().getItemManager().deleteItem(item);
@@ -1006,7 +1105,7 @@ public class RoomItemManager {
 
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
+        for (int i = this.roomItems.size(); i-- > 0;) {
             try {
                 iterator.advance();
             } catch (Exception e) {
@@ -1024,7 +1123,7 @@ public class RoomItemManager {
         if (habbo != null) {
             THashSet<HabboItem> normalItems = new THashSet<>();
             for (HabboItem item : items) {
-                if (!SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+                if (!item.isBuildersClub()) {
                     normalItems.add(item);
                 }
             }
@@ -1036,7 +1135,7 @@ public class RoomItemManager {
         }
 
         for (HabboItem i : items) {
-            if (SubscriptionBuildersClub.isBuildersClubItemId(i.getId())) {
+            if (i.isBuildersClub()) {
                 this.pickUpBuildersClubItem(i, null);
             } else {
                 this.pickUpItem(i, null);
@@ -1048,7 +1147,7 @@ public class RoomItemManager {
      * Ejects a single user item.
      */
     public void ejectUserItem(HabboItem item) {
-        if (SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+        if (item.isBuildersClub()) {
             this.pickUpBuildersClubItem(item, null);
             return;
         }
@@ -1072,7 +1171,7 @@ public class RoomItemManager {
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-            for (int i = this.roomItems.size(); i-- > 0; ) {
+            for (int i = this.roomItems.size(); i-- > 0;) {
                 try {
                     iterator.advance();
                 } catch (Exception e) {
@@ -1088,13 +1187,13 @@ public class RoomItemManager {
                 }
 
                 userItemsMap.computeIfAbsent(iterator.value().getUserId(), k -> new THashSet<>())
-                    .add(iterator.value());
+                        .add(iterator.value());
             }
         }
 
         for (Map.Entry<Integer, THashSet<HabboItem>> entrySet : userItemsMap.entrySet()) {
             for (HabboItem i : entrySet.getValue()) {
-                if (SubscriptionBuildersClub.isBuildersClubItemId(i.getId())) {
+                if (i.isBuildersClub()) {
                     this.pickUpBuildersClubItem(i, null);
                 } else {
                     this.pickUpItem(i, null);
@@ -1106,7 +1205,7 @@ public class RoomItemManager {
             if (user != null) {
                 THashSet<HabboItem> normalItems = new THashSet<>();
                 for (HabboItem item : entrySet.getValue()) {
-                    if (!SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+                    if (!item.isBuildersClub()) {
                         normalItems.add(item);
                     }
                 }
@@ -1125,7 +1224,7 @@ public class RoomItemManager {
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-            for (int i = this.roomItems.size(); i-- > 0; ) {
+            for (int i = this.roomItems.size(); i-- > 0;) {
                 try {
                     iterator.advance();
                 } catch (Exception e) {
@@ -1133,7 +1232,7 @@ public class RoomItemManager {
                 }
 
                 HabboItem item = iterator.value();
-                if (item != null && item.getUserId() == userId && SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+                if (item != null && item.getUserId() == userId && item.isBuildersClub()) {
                     items.add(item);
                 }
             }
@@ -1148,14 +1247,14 @@ public class RoomItemManager {
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-            for (int i = this.roomItems.size(); i-- > 0; ) {
+            for (int i = this.roomItems.size(); i-- > 0;) {
                 try {
                     iterator.advance();
                 } catch (Exception e) {
                     break;
                 }
 
-                if (SubscriptionBuildersClub.isBuildersClubItemId(iterator.value().getId())) {
+                if (iterator.value().isBuildersClub()) {
                     return true;
                 }
             }
@@ -1174,7 +1273,7 @@ public class RoomItemManager {
 
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
+        for (int i = this.roomItems.size(); i-- > 0;) {
             HabboItem item;
             try {
                 iterator.advance();
@@ -1200,7 +1299,7 @@ public class RoomItemManager {
                     for (short y = 0; y < item.getBaseItem().getLength(); y++) {
                         for (short x = 0; x < item.getBaseItem().getWidth(); x++) {
                             RoomTile tile = this.room.getLayout().getTile(
-                                (short) (item.getX() + x), (short) (item.getY() + y));
+                                    (short) (item.getX() + x), (short) (item.getY() + y));
 
                             if (tile != null) {
                                 lockedTiles.add(tile);
@@ -1211,7 +1310,7 @@ public class RoomItemManager {
                     for (short y = 0; y < item.getBaseItem().getWidth(); y++) {
                         for (short x = 0; x < item.getBaseItem().getLength(); x++) {
                             RoomTile tile = this.room.getLayout().getTile(
-                                (short) (item.getX() + x), (short) (item.getY() + y));
+                                    (short) (item.getX() + x), (short) (item.getY() + y));
 
                             if (tile != null) {
                                 lockedTiles.add(tile);
@@ -1234,7 +1333,7 @@ public class RoomItemManager {
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
-            for (int i = this.roomItems.size(); i-- > 0; ) {
+            for (int i = this.roomItems.size(); i-- > 0;) {
                 try {
                     iterator.advance();
 
@@ -1302,8 +1401,9 @@ public class RoomItemManager {
 
         rotation %= 8;
         if (this.room.hasRights(habbo) || this.room.getGuildRightLevel(habbo)
-            .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS) || habbo.hasPermission(
-            Permission.ACC_MOVEROTATE)) {
+                .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS)
+                || habbo.hasPermission(
+                        Permission.ACC_MOVEROTATE)) {
             return FurnitureMovementError.NONE;
         }
 
@@ -1314,8 +1414,8 @@ public class RoomItemManager {
                 if (!RoomLayout.squareInSquare(RoomLayout.getRectangle(rentSpace.getX(), rentSpace.getY(),
                         rentSpace.getBaseItem().getWidth(), rentSpace.getBaseItem().getLength(),
                         rentSpace.getRotation()),
-                    RoomLayout.getRectangle(tile.x, tile.y, item.getBaseItem().getWidth(),
-                        item.getBaseItem().getLength(), rotation))) {
+                        RoomLayout.getRectangle(tile.x, tile.y, item.getBaseItem().getWidth(),
+                                item.getBaseItem().getLength(), rotation))) {
                     return FurnitureMovementError.NO_RIGHTS;
                 } else {
                     return FurnitureMovementError.NONE;
@@ -1325,7 +1425,7 @@ public class RoomItemManager {
 
         for (HabboItem area : this.room.getRoomSpecialTypes().getItemsOfType(InteractionBuildArea.class)) {
             if (((InteractionBuildArea) area).inSquare(tile) && ((InteractionBuildArea) area).isBuilder(
-                habbo.getHabboInfo().getUsername())) {
+                    habbo.getHabboInfo().getUsername())) {
                 return FurnitureMovementError.NONE;
             }
         }
@@ -1354,14 +1454,14 @@ public class RoomItemManager {
         }
 
         THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
-            item.getBaseItem().getLength(), rotation);
+                item.getBaseItem().getLength(), rotation);
         for (RoomTile t : occupiedTiles) {
             if (t.state == RoomTileState.INVALID) {
                 return FurnitureMovementError.INVALID_MOVE;
             }
-            if (!Emulator.getConfig().getBoolean("wired.place.under", false) || (
-                Emulator.getConfig().getBoolean("wired.place.under", false) && !item.isWalkable()
-                    && !item.getBaseItem().allowSit() && !item.getBaseItem().allowLay())) {
+            if (!Emulator.getConfig().getBoolean("wired.place.under", false)
+                    || (Emulator.getConfig().getBoolean("wired.place.under", false) && !item.isWalkable()
+                            && !item.getBaseItem().allowSit() && !item.getBaseItem().allowLay())) {
                 if (checkForUnits && this.room.hasHabbosAt(t.x, t.y)) {
                     return FurnitureMovementError.TILE_HAS_HABBOS;
                 }
@@ -1398,7 +1498,7 @@ public class RoomItemManager {
         boolean pluginHelper = false;
         if (Emulator.getPluginManager().isRegistered(FurniturePlacedEvent.class, true)) {
             FurniturePlacedEvent event = Emulator.getPluginManager()
-                .fireEvent(new FurniturePlacedEvent(item, owner, tile));
+                    .fireEvent(new FurniturePlacedEvent(item, owner, tile));
 
             if (event.isCancelled()) {
                 return FurnitureMovementError.CANCEL_PLUGIN_PLACE;
@@ -1409,7 +1509,7 @@ public class RoomItemManager {
 
         RoomLayout layout = this.room.getLayout();
         THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
-            item.getBaseItem().getLength(), rotation);
+                item.getBaseItem().getLength(), rotation);
 
         FurnitureMovementError fits = furnitureFitsAt(tile, item, rotation);
 
@@ -1428,7 +1528,7 @@ public class RoomItemManager {
 
         if (Emulator.getPluginManager().isRegistered(FurnitureBuildheightEvent.class, true)) {
             FurnitureBuildheightEvent event = Emulator.getPluginManager()
-                .fireEvent(new FurnitureBuildheightEvent(item, owner, 0.00, height));
+                    .fireEvent(new FurnitureBuildheightEvent(item, owner, 0.00, height));
             if (event.hasChangedHeight()) {
                 height = layout.getHeightAtSquare(tile.x, tile.y) + event.getUpdatedHeight();
             }
@@ -1448,7 +1548,7 @@ public class RoomItemManager {
         item.onPlace(this.room);
         this.room.updateTiles(occupiedTiles);
         this.room.sendComposer(
-            new ObjectAddMessageComposer(item, this.getFurniOwnerName(item.getUserId())).compose());
+                new ObjectAddMessageComposer(item, this.getFurniOwnerName(item.getUserId())).compose());
 
         for (RoomTile t : occupiedTiles) {
             this.room.updateHabbosAt(t.x, t.y);
@@ -1464,7 +1564,7 @@ public class RoomItemManager {
      */
     public FurnitureMovementError placeWallFurniAt(HabboItem item, String wallPosition, Habbo owner) {
         if (!(this.room.hasRights(owner) || this.room.getGuildRightLevel(owner)
-            .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
+                .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
             return FurnitureMovementError.NO_RIGHTS;
         }
 
@@ -1482,7 +1582,7 @@ public class RoomItemManager {
             this.furniOwnerNames.put(item.getUserId(), owner.getHabboInfo().getUsername());
         }
         this.room.sendComposer(
-            new ItemAddMessageComposer(item, this.getFurniOwnerName(item.getUserId())).compose());
+                new ItemAddMessageComposer(item, this.getFurniOwnerName(item.getUserId())).compose());
         item.needsUpdate(true);
         this.addHabboItem(item);
         item.setRoomId(this.room.getId());
@@ -1501,21 +1601,23 @@ public class RoomItemManager {
     /**
      * Moves furniture to a new position with send updates option.
      */
-    public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, Habbo actor, boolean sendUpdates) {
+    public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, Habbo actor,
+            boolean sendUpdates) {
         return moveFurniTo(item, tile, rotation, actor, sendUpdates, true);
     }
 
     /**
      * Moves furniture to a new position with full options.
      */
-    public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, Habbo actor, boolean sendUpdates, boolean checkForUnits) {
+    public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, Habbo actor,
+            boolean sendUpdates, boolean checkForUnits) {
         RoomLayout layout = this.room.getLayout();
         RoomTile oldLocation = layout.getTile(item.getX(), item.getY());
 
         boolean pluginHelper = false;
         if (Emulator.getPluginManager().isRegistered(FurnitureMovedEvent.class, true)) {
             FurnitureMovedEvent event = Emulator.getPluginManager()
-                .fireEvent(new FurnitureMovedEvent(item, actor, oldLocation, tile));
+                    .fireEvent(new FurnitureMovedEvent(item, actor, oldLocation, tile));
             if (event.isCancelled()) {
                 return FurnitureMovementError.CANCEL_PLUGIN_MOVE;
             }
@@ -1525,13 +1627,13 @@ public class RoomItemManager {
         boolean magicTile = item instanceof InteractionStackHelper || item instanceof InteractionTileWalkMagic;
 
         java.util.Optional<HabboItem> stackHelper = this.getItemsAt(tile).stream()
-            .filter(i -> i instanceof InteractionStackHelper).findAny();
+                .filter(i -> i instanceof InteractionStackHelper).findAny();
 
         // Check if can be placed at new position
         THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
-            item.getBaseItem().getLength(), rotation);
+                item.getBaseItem().getLength(), rotation);
         THashSet<RoomTile> newOccupiedTiles = layout.getTilesAt(tile,
-            item.getBaseItem().getWidth(), item.getBaseItem().getLength(), rotation);
+                item.getBaseItem().getWidth(), item.getBaseItem().getLength(), rotation);
 
         HabboItem topItem = this.getTopItemAt(occupiedTiles, null);
 
@@ -1539,16 +1641,16 @@ public class RoomItemManager {
             if (oldLocation != tile) {
                 for (RoomTile t : occupiedTiles) {
                     HabboItem tileTopItem = this.getTopItemAt(t.x, t.y);
-                    if (!magicTile && ((tileTopItem != null && tileTopItem != item ? (
-                        t.state.equals(RoomTileState.INVALID) || !t.getAllowStack()
-                            || !tileTopItem.getBaseItem().allowStack())
-                        : this.room.calculateTileState(t, item).equals(RoomTileState.INVALID)))) {
+                    if (!magicTile && ((tileTopItem != null && tileTopItem != item
+                            ? (t.state.equals(RoomTileState.INVALID) || !t.getAllowStack()
+                                    || !tileTopItem.getBaseItem().allowStack())
+                            : this.room.calculateTileState(t, item).equals(RoomTileState.INVALID)))) {
                         return FurnitureMovementError.CANT_STACK;
                     }
 
-                    if (!Emulator.getConfig().getBoolean("wired.place.under", false) || (
-                        Emulator.getConfig().getBoolean("wired.place.under", false) && !item.isWalkable()
-                            && !item.getBaseItem().allowSit() && !item.getBaseItem().allowLay())) {
+                    if (!Emulator.getConfig().getBoolean("wired.place.under", false)
+                            || (Emulator.getConfig().getBoolean("wired.place.under", false) && !item.isWalkable()
+                                    && !item.getBaseItem().allowSit() && !item.getBaseItem().allowLay())) {
                         if (checkForUnits) {
                             if (!magicTile && this.room.hasHabbosAt(t.x, t.y)) {
                                 return FurnitureMovementError.TILE_HAS_HABBOS;
@@ -1575,8 +1677,8 @@ public class RoomItemManager {
         }
 
         THashSet<RoomTile> oldOccupiedTiles = layout.getTilesAt(
-            layout.getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(),
-            item.getBaseItem().getLength(), item.getRotation());
+                layout.getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(),
+                item.getBaseItem().getLength(), item.getRotation());
 
         int oldRotation = item.getRotation();
 
@@ -1593,9 +1695,9 @@ public class RoomItemManager {
             }
 
             if ((!stackHelper.isPresent() && topItem != null && topItem != item && !topItem.getBaseItem()
-                .allowStack()) || (topItem != null && topItem != item
-                && topItem.getZ() + Item.getCurrentHeight(topItem) + Item.getCurrentHeight(item)
-                > Room.MAXIMUM_FURNI_HEIGHT)) {
+                    .allowStack()) || (topItem != null && topItem != item
+                            && topItem.getZ() + Item.getCurrentHeight(topItem)
+                                    + Item.getCurrentHeight(item) > Room.MAXIMUM_FURNI_HEIGHT)) {
                 item.setRotation(oldRotation);
                 return FurnitureMovementError.CANT_STACK;
             }
@@ -1606,7 +1708,7 @@ public class RoomItemManager {
 
         if (stackHelper.isPresent()) {
             height = stackHelper.get().getExtradata().isEmpty() ? Double.parseDouble("0.0")
-                : (Double.parseDouble(stackHelper.get().getExtradata()) / 100);
+                    : (Double.parseDouble(stackHelper.get().getExtradata()) / 100);
         } else if (item == topItem) {
             height = item.getZ();
         } else if (magicTile) {
@@ -1643,7 +1745,7 @@ public class RoomItemManager {
 
         if (Emulator.getPluginManager().isRegistered(FurnitureBuildheightEvent.class, true)) {
             FurnitureBuildheightEvent event = Emulator.getPluginManager()
-                .fireEvent(new FurnitureBuildheightEvent(item, actor, 0.00, height));
+                    .fireEvent(new FurnitureBuildheightEvent(item, actor, 0.00, height));
             if (event.hasChangedHeight()) {
                 height = layout.getHeightAtSquare(tile.x, tile.y) + event.getUpdatedHeight();
                 pluginHeight = true;
@@ -1664,19 +1766,23 @@ public class RoomItemManager {
         if (item.getZ() > Room.MAXIMUM_FURNI_HEIGHT) {
             item.setZ(Room.MAXIMUM_FURNI_HEIGHT);
         }
-        
+
         // Update wired spatial index and invalidate cache when wired items are moved
         if (item instanceof InteractionWiredTrigger) {
-            this.room.getRoomSpecialTypes().updateTriggerLocation((InteractionWiredTrigger) item, oldLocation.x, oldLocation.y);
+            this.room.getRoomSpecialTypes().updateTriggerLocation((InteractionWiredTrigger) item, oldLocation.x,
+                    oldLocation.y);
             WiredManager.invalidateRoom(this.room);
         } else if (item instanceof InteractionWiredEffect) {
-            this.room.getRoomSpecialTypes().updateEffectLocation((InteractionWiredEffect) item, oldLocation.x, oldLocation.y);
+            this.room.getRoomSpecialTypes().updateEffectLocation((InteractionWiredEffect) item, oldLocation.x,
+                    oldLocation.y);
             WiredManager.invalidateRoom(this.room);
         } else if (item instanceof InteractionWiredCondition) {
-            this.room.getRoomSpecialTypes().updateConditionLocation((InteractionWiredCondition) item, oldLocation.x, oldLocation.y);
+            this.room.getRoomSpecialTypes().updateConditionLocation((InteractionWiredCondition) item, oldLocation.x,
+                    oldLocation.y);
             WiredManager.invalidateRoom(this.room);
         } else if (item instanceof InteractionWiredExtra) {
-            this.room.getRoomSpecialTypes().updateExtraLocation((InteractionWiredExtra) item, oldLocation.x, oldLocation.y);
+            this.room.getRoomSpecialTypes().updateExtraLocation((InteractionWiredExtra) item, oldLocation.x,
+                    oldLocation.y);
             WiredManager.invalidateRoom(this.room);
         }
 
@@ -1720,10 +1826,10 @@ public class RoomItemManager {
         boolean magicTile = item instanceof InteractionStackHelper;
 
         RoomLayout layout = this.room.getLayout();
-        
+
         // Check if can be placed at new position
         THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
-            item.getBaseItem().getLength(), rotation);
+                item.getBaseItem().getLength(), rotation);
 
         java.util.List<Pair<RoomTile, THashSet<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
         for (RoomTile t : occupiedTiles) {

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -1263,6 +1263,27 @@ public class RoomItemManager {
         return false;
     }
 
+    public boolean hasUserBuildersClubItems(int userId) {
+        synchronized (this.roomItems) {
+            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
+
+            for (int i = this.roomItems.size(); i-- > 0;) {
+                try {
+                    iterator.advance();
+                } catch (Exception e) {
+                    break;
+                }
+
+                HabboItem item = iterator.value();
+                if (item.isBuildersClub() && item.getUserId() == userId) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     // ==================== LOCKED TILES ====================
 
     /**

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -36,6 +36,7 @@ import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.outgoing.rooms.items.ObjectAddMessageComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemAddMessageComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.FloorItemOnRollerComposer;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.furniture.FurnitureBuildheightEvent;
 import com.eu.habbo.plugin.events.furniture.FurnitureMovedEvent;
@@ -956,6 +957,47 @@ public class RoomItemManager {
         Emulator.getThreading().run(item);
     }
 
+    public void pickUpBuildersClubItem(HabboItem item, Habbo picker) {
+        if (item == null || !SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+            return;
+        }
+
+        if (Emulator.getPluginManager().isRegistered(FurniturePickedUpEvent.class, true)) {
+            FurniturePickedUpEvent event = Emulator.getPluginManager().fireEvent(new FurniturePickedUpEvent(item, picker));
+
+            if (event.isCancelled()) {
+                return;
+            }
+        }
+
+        this.removeHabboItem(item);
+        item.onPickUp(this.room);
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            this.room.sendComposer(new ObjectRemoveMessageComposer(item).compose());
+
+            THashSet<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
+                    this.room.getLayout().getTile(item.getX(), item.getY()),
+                    item.getBaseItem().getWidth(),
+                    item.getBaseItem().getLength(),
+                    item.getRotation());
+            this.room.updateTiles(updatedTiles);
+
+            for (RoomTile tile : updatedTiles) {
+                this.room.updateHabbosAt(tile.x, tile.y);
+                this.room.updateBotsAt(tile.x, tile.y);
+            }
+        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
+            this.room.sendComposer(new ItemRemoveMessageComposer(item).compose());
+        }
+
+        Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+        Habbo owner = Emulator.getGameEnvironment().getHabboManager().getHabbo(item.getUserId());
+        if (owner != null) {
+            owner.getHabboStats().invalidateBuildersClubFurniCount();
+        }
+    }
+
     /**
      * Ejects all furniture belonging to a user.
      */
@@ -980,12 +1022,25 @@ public class RoomItemManager {
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
 
         if (habbo != null) {
-            habbo.getInventory().getItemsComponent().addItems(items);
-            habbo.getClient().sendResponse(new UnseenItemsMessageComposer(items));
+            THashSet<HabboItem> normalItems = new THashSet<>();
+            for (HabboItem item : items) {
+                if (!SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+                    normalItems.add(item);
+                }
+            }
+
+            if (!normalItems.isEmpty()) {
+                habbo.getInventory().getItemsComponent().addItems(normalItems);
+                habbo.getClient().sendResponse(new UnseenItemsMessageComposer(normalItems));
+            }
         }
 
         for (HabboItem i : items) {
-            this.pickUpItem(i, null);
+            if (SubscriptionBuildersClub.isBuildersClubItemId(i.getId())) {
+                this.pickUpBuildersClubItem(i, null);
+            } else {
+                this.pickUpItem(i, null);
+            }
         }
     }
 
@@ -993,6 +1048,11 @@ public class RoomItemManager {
      * Ejects a single user item.
      */
     public void ejectUserItem(HabboItem item) {
+        if (SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+            this.pickUpBuildersClubItem(item, null);
+            return;
+        }
+
         this.pickUpItem(item, null);
     }
 
@@ -1034,16 +1094,74 @@ public class RoomItemManager {
 
         for (Map.Entry<Integer, THashSet<HabboItem>> entrySet : userItemsMap.entrySet()) {
             for (HabboItem i : entrySet.getValue()) {
-                this.pickUpItem(i, null);
+                if (SubscriptionBuildersClub.isBuildersClubItemId(i.getId())) {
+                    this.pickUpBuildersClubItem(i, null);
+                } else {
+                    this.pickUpItem(i, null);
+                }
             }
 
             Habbo user = Emulator.getGameEnvironment().getHabboManager().getHabbo(entrySet.getKey());
 
             if (user != null) {
-                user.getInventory().getItemsComponent().addItems(entrySet.getValue());
-                user.getClient().sendResponse(new UnseenItemsMessageComposer(entrySet.getValue()));
+                THashSet<HabboItem> normalItems = new THashSet<>();
+                for (HabboItem item : entrySet.getValue()) {
+                    if (!SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+                        normalItems.add(item);
+                    }
+                }
+
+                if (!normalItems.isEmpty()) {
+                    user.getInventory().getItemsComponent().addItems(normalItems);
+                    user.getClient().sendResponse(new UnseenItemsMessageComposer(normalItems));
+                }
             }
         }
+    }
+
+    public void pickUpBuildersClubItems(int userId, Habbo picker) {
+        THashSet<HabboItem> items = new THashSet<>();
+
+        synchronized (this.roomItems) {
+            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
+
+            for (int i = this.roomItems.size(); i-- > 0; ) {
+                try {
+                    iterator.advance();
+                } catch (Exception e) {
+                    break;
+                }
+
+                HabboItem item = iterator.value();
+                if (item != null && item.getUserId() == userId && SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+                    items.add(item);
+                }
+            }
+        }
+
+        for (HabboItem item : items) {
+            this.pickUpBuildersClubItem(item, picker);
+        }
+    }
+
+    public boolean hasBuildersClubItems() {
+        synchronized (this.roomItems) {
+            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
+
+            for (int i = this.roomItems.size(); i-- > 0; ) {
+                try {
+                    iterator.advance();
+                } catch (Exception e) {
+                    break;
+                }
+
+                if (SubscriptionBuildersClub.isBuildersClubItemId(iterator.value().getId())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     // ==================== LOCKED TILES ====================

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -27,6 +27,7 @@ import com.eu.habbo.habbohotel.polls.Poll;
 import com.eu.habbo.habbohotel.polls.PollManager;
 import com.eu.habbo.habbohotel.users.*;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.messages.incoming.users.NewUserExperienceScriptProceedEvent;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
 import com.eu.habbo.messages.outgoing.hotelview.CloseConnectionMessageComposer;
@@ -528,6 +529,21 @@ public class RoomManager {
 
         if (room.isBanned(habbo) && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER) && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
             habbo.getClient().sendResponse(new CantConnectMessageComposer(CantConnectMessageComposer.ROOM_ERROR_BANNED));
+            return;
+        }
+
+        boolean buildersClubLockBypass = overrideChecks
+                || room.isOwner(habbo)
+                || habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                || habbo.hasPermission(Permission.ACC_ENTERANYROOM)
+                || room.hasRights(habbo)
+                || (room.hasGuild() && room.getGuildRightLevel(habbo).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS));
+
+        if (SubscriptionBuildersClub.shouldLockRoom(room) && !buildersClubLockBypass) {
+            SubscriptionBuildersClub.notifyBuildersClubVisitorDenied(room, habbo);
+            habbo.getClient().sendResponse(new CantConnectMessageComposer(CantConnectMessageComposer.ROOM_ERROR_CANT_ENTER, CantConnectMessageComposer.ROOM_LOCKED));
+            habbo.getClient().sendResponse(new CloseConnectionMessageComposer());
+            habbo.getHabboInfo().setLoadingRoom(0);
             return;
         }
 

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
@@ -36,7 +36,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboItem.class);
 
-    private static Class<?>[] TOGGLING_INTERACTIONS = new Class<?>[]{
+    private static Class<?>[] TOGGLING_INTERACTIONS = new Class<?>[] {
             InteractionGameTimer.class,
             InteractionWired.class,
             InteractionWiredHighscore.class,
@@ -58,9 +58,12 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     private boolean needsUpdate = false;
     private boolean needsDelete = false;
     private boolean isFromGift = false;
+    private boolean buildersClub = false;
+    private transient int roomVisibleId = -1; // -1 = use real id
 
     public HabboItem(ResultSet set, Item baseItem) throws SQLException {
         this.id = set.getInt("id");
+        this.buildersClub = set.getBoolean("is_builders_club");
         this.userId = set.getInt("user_id");
         this.roomId = set.getInt("room_id");
         this.baseItem = baseItem;
@@ -99,15 +102,23 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
 
     public void serializeFloorData(ServerMessage serverMessage) {
         try {
-            serverMessage.appendInt(this.getId());
+            serverMessage.appendInt(this.getRoomVisibleId());
             serverMessage.appendInt(this.baseItem.getSpriteId());
             serverMessage.appendInt(this.x);
             serverMessage.appendInt(this.y);
             serverMessage.appendInt(this.getRotation());
             serverMessage.appendString(Double.toString(this.z));
 
-            serverMessage.appendString((this.getBaseItem().getInteractionType().getType() == InteractionTrophy.class || this.getBaseItem().getInteractionType().getType() == InteractionCrackable.class || this.getBaseItem().getName().equalsIgnoreCase("gnome_box")) ? "1.0" : ((this.getBaseItem().allowWalk() || this.getBaseItem().allowSit() && this.roomId != 0) ? Item.getCurrentHeight(this) + "" : ""));
-            //serverMessage.appendString( ? "1.0" : ((this.getBaseItem().allowWalk() || this.getBaseItem().allowSit() && this.roomId != 0) ? Item.getCurrentHeight(this) : ""));
+            serverMessage.appendString((this.getBaseItem().getInteractionType().getType() == InteractionTrophy.class
+                    || this.getBaseItem().getInteractionType().getType() == InteractionCrackable.class
+                    || this.getBaseItem().getName().equalsIgnoreCase("gnome_box"))
+                            ? "1.0"
+                            : ((this.getBaseItem().allowWalk() || this.getBaseItem().allowSit() && this.roomId != 0)
+                                    ? Item.getCurrentHeight(this) + ""
+                                    : ""));
+            // serverMessage.appendString( ? "1.0" : ((this.getBaseItem().allowWalk() ||
+            // this.getBaseItem().allowSit() && this.roomId != 0) ?
+            // Item.getCurrentHeight(this) : ""));
 
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
@@ -122,7 +133,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     }
 
     public void serializeWallData(ServerMessage serverMessage) {
-        serverMessage.appendString(this.getId() + "");
+        serverMessage.appendString(this.getRoomVisibleId() + "");
         serverMessage.appendInt(this.baseItem.getSpriteId());
         serverMessage.appendString(this.wallPosition);
 
@@ -140,9 +151,11 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     }
 
     public int getGiftAdjustedId() {
-        if (this.isFromGift) return -this.id;
+        int visibleId = this.getRoomVisibleId();
+        if (this.isFromGift)
+            return -visibleId;
 
-        return this.id;
+        return visibleId;
     }
 
     public int getUserId() {
@@ -194,7 +207,8 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     }
 
     public void setZ(double z) {
-        if (z > 9999 || z < -9999) return;
+        if (z > 9999 || z < -9999)
+            return;
         this.z = z;
     }
 
@@ -212,6 +226,26 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
 
     public void setExtradata(String extradata) {
         this.extradata = extradata;
+    }
+
+    public boolean isBuildersClub() {
+        return this.buildersClub;
+    }
+
+    public void setBuildersClub(boolean buildersClub) {
+        this.buildersClub = buildersClub;
+    }
+
+    public int getRoomVisibleId() {
+        return this.roomVisibleId != -1 ? this.roomVisibleId : this.id;
+    }
+
+    public void setRoomVisibleId(int roomVisibleId) {
+        this.roomVisibleId = roomVisibleId;
+    }
+
+    public void clearRoomVisibleId() {
+        this.roomVisibleId = -1;
     }
 
     public boolean needsUpdate() {
@@ -242,7 +276,9 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
         return this.limitedSells;
     }
 
-    public int getMaximumRotations() { return this.baseItem.getRotations(); }
+    public int getMaximumRotations() {
+        return this.baseItem.getRotations();
+    }
 
     @Override
     public void run() {
@@ -256,13 +292,15 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
                     statement.execute();
                 }
             } else if (this.needsUpdate) {
-                try (PreparedStatement statement = connection.prepareStatement("UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, x = ?, y = ?, z = ?, rot = ?, extra_data = ?, limited_data = ? WHERE id = ?")) {
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, x = ?, y = ?, z = ?, rot = ?, extra_data = ?, limited_data = ? WHERE id = ?")) {
                     statement.setInt(1, this.userId);
                     statement.setInt(2, this.roomId);
                     statement.setString(3, this.wallPosition);
                     statement.setInt(4, this.x);
                     statement.setInt(5, this.y);
-                    statement.setDouble(6, Math.max(-9999, Math.min(9999, Math.round(this.z * Math.pow(10, 6)) / Math.pow(10, 6))));
+                    statement.setDouble(6,
+                            Math.max(-9999, Math.min(9999, Math.round(this.z * Math.pow(10, 6)) / Math.pow(10, 6))));
                     statement.setInt(7, this.rotation);
                     statement.setString(8, this instanceof InteractionGuildGate ? "" : this.getDatabaseExtraData());
                     statement.setString(9, this.limitedStack + ":" + this.limitedSells);
@@ -294,7 +332,9 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
                 }
             }
 
-            if ((this.getBaseItem().getStateCount() > 1 && !(this instanceof InteractionDice)) || Arrays.asList(HabboItem.TOGGLING_INTERACTIONS).contains(this.getClass()) || (objects != null && objects.length == 1 && objects[0].equals("TOGGLE_OVERRIDE"))) {
+            if ((this.getBaseItem().getStateCount() > 1 && !(this instanceof InteractionDice))
+                    || Arrays.asList(HabboItem.TOGGLING_INTERACTIONS).contains(this.getClass())
+                    || (objects != null && objects.length == 1 && objects[0].equals("TOGGLE_OVERRIDE"))) {
                 WiredManager.triggerFurniStateChanged(room, client.getHabbo().getRoomUnit(), this);
             }
         }
@@ -302,22 +342,33 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
 
     @Override
     public void onWalkOn(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
-        /*if (objects != null && objects.length >= 1 && objects[0] instanceof InteractionWired)
-            return;*/
+        /*
+         * if (objects != null && objects.length >= 1 && objects[0] instanceof
+         * InteractionWired)
+         * return;
+         */
 
         WiredManager.triggerUserWalksOn(room, roomUnit, this);
 
-        if ((this.getBaseItem().allowSit() || this.getBaseItem().allowLay()) && !roomUnit.getDanceType().equals(DanceType.NONE)) {
+        if ((this.getBaseItem().allowSit() || this.getBaseItem().allowLay())
+                && !roomUnit.getDanceType().equals(DanceType.NONE)) {
             roomUnit.setDanceType(DanceType.NONE);
             room.sendComposer(new DanceMessageComposer(roomUnit).compose());
         }
 
-        if (!this.getBaseItem().getClothingOnWalk().isEmpty() && roomUnit.getPreviousLocation() != roomUnit.getGoal() && roomUnit.getGoal() == room.getLayout().getTile(this.x, this.y)) {
+        if (!this.getBaseItem().getClothingOnWalk().isEmpty() && roomUnit.getPreviousLocation() != roomUnit.getGoal()
+                && roomUnit.getGoal() == room.getLayout().getTile(this.x, this.y)) {
             Habbo habbo = room.getHabbo(roomUnit);
 
             if (habbo != null && habbo.getClient() != null) {
-                String[] clothingKeys = Arrays.stream(this.getBaseItem().getClothingOnWalk().split("\\.")).map(k -> k.split("-")[0]).toArray(String[]::new);
-                habbo.getHabboInfo().setLook(String.join(".", Arrays.stream(habbo.getHabboInfo().getLook().split("\\.")).filter(k -> !ArrayUtils.contains(clothingKeys, k.split("-")[0])).toArray(String[]::new)) + "." + this.getBaseItem().getClothingOnWalk());
+                String[] clothingKeys = Arrays.stream(this.getBaseItem().getClothingOnWalk().split("\\."))
+                        .map(k -> k.split("-")[0]).toArray(String[]::new);
+                habbo.getHabboInfo()
+                        .setLook(String.join(".",
+                                Arrays.stream(habbo.getHabboInfo().getLook().split("\\."))
+                                        .filter(k -> !ArrayUtils.contains(clothingKeys, k.split("-")[0]))
+                                        .toArray(String[]::new))
+                                + "." + this.getBaseItem().getClothingOnWalk());
 
                 habbo.getClient().sendResponse(new FigureUpdateMessageComposer(habbo));
                 if (habbo.getHabboInfo().getCurrentRoom() != null) {
@@ -329,22 +380,24 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
 
     @Override
     public void onWalkOff(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
-        if(objects != null && objects.length > 0) {
+        if (objects != null && objects.length > 0) {
             WiredManager.triggerUserWalksOff(room, roomUnit, this);
         }
     }
 
     public abstract void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception;
 
-
     public void onPlace(Room room) {
-        //TODO: IMPORTANT: MAKE THIS GENERIC. (HOLES, ICE SKATE PATCHES, BLACK HOLE, BUNNY RUN FIELD, FOOTBALL FIELD)
-        Achievement roomDecoAchievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement("RoomDecoFurniCount");
+        // TODO: IMPORTANT: MAKE THIS GENERIC. (HOLES, ICE SKATE PATCHES, BLACK HOLE,
+        // BUNNY RUN FIELD, FOOTBALL FIELD)
+        Achievement roomDecoAchievement = Emulator.getGameEnvironment().getAchievementManager()
+                .getAchievement("RoomDecoFurniCount");
         Habbo owner = room.getHabbo(this.getUserId());
 
         int furniCollecterProgress;
         if (owner == null) {
-            furniCollecterProgress = AchievementManager.getAchievementProgressForHabbo(this.getUserId(), roomDecoAchievement);
+            furniCollecterProgress = AchievementManager.getAchievementProgressForHabbo(this.getUserId(),
+                    roomDecoAchievement);
         } else {
             furniCollecterProgress = owner.getHabboStats().getAchievementProgress(roomDecoAchievement);
         }
@@ -358,11 +411,13 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
             }
         }
 
-        Achievement roomDecoUniqueAchievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement("RoomDecoFurniTypeCount");
+        Achievement roomDecoUniqueAchievement = Emulator.getGameEnvironment().getAchievementManager()
+                .getAchievement("RoomDecoFurniTypeCount");
 
         int uniqueFurniCollecterProgress;
         if (owner == null) {
-            uniqueFurniCollecterProgress = AchievementManager.getAchievementProgressForHabbo(this.getUserId(), roomDecoUniqueAchievement);
+            uniqueFurniCollecterProgress = AchievementManager.getAchievementProgressForHabbo(this.getUserId(),
+                    roomDecoUniqueAchievement);
         } else {
             uniqueFurniCollecterProgress = owner.getHabboStats().getAchievementProgress(roomDecoUniqueAchievement);
         }
@@ -383,27 +438,31 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
             int nextEffectM = 0;
             int nextEffectF = 0;
 
-            if(topItem2 != null) {
+            if (topItem2 != null) {
                 nextEffectM = topItem2.getBaseItem().getEffectM();
                 nextEffectF = topItem2.getBaseItem().getEffectF();
             }
 
             for (Habbo habbo : room.getHabbosOnItem(this)) {
-                if (this.getBaseItem().getEffectM() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.M) && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
+                if (this.getBaseItem().getEffectM() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.M)
+                        && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
                     room.giveEffect(habbo, nextEffectM, -1);
                 }
 
-                if (this.getBaseItem().getEffectF() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.F) && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
+                if (this.getBaseItem().getEffectF() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.F)
+                        && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
                     room.giveEffect(habbo, nextEffectF, -1);
                 }
             }
 
             for (Bot bot : room.getBotsAt(room.getLayout().getTile(this.getX(), this.getY()))) {
-                if (this.getBaseItem().getEffectM() > 0 && bot.getGender().equals(HabboGender.M) && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
+                if (this.getBaseItem().getEffectM() > 0 && bot.getGender().equals(HabboGender.M)
+                        && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
                     room.giveEffect(bot.getRoomUnit(), nextEffectM, -1);
                 }
 
-                if (this.getBaseItem().getEffectF() > 0 && bot.getGender().equals(HabboGender.F) && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
+                if (this.getBaseItem().getEffectF() > 0 && bot.getGender().equals(HabboGender.F)
+                        && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
                     room.giveEffect(bot.getRoomUnit(), nextEffectF, -1);
                 }
             }
@@ -416,7 +475,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
             int nextEffectM = 0;
             int nextEffectF = 0;
 
-            if(topItem2 != null) {
+            if (topItem2 != null) {
                 nextEffectM = topItem2.getBaseItem().getEffectM();
                 nextEffectF = topItem2.getBaseItem().getEffectF();
             }
@@ -426,12 +485,14 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
             List<Bot> oldBots = new ArrayList<>();
             List<Bot> newBots = new ArrayList<>();
 
-            for (RoomTile tile : room.getLayout().getTilesAt(oldLocation, this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation())) {
+            for (RoomTile tile : room.getLayout().getTilesAt(oldLocation, this.getBaseItem().getWidth(),
+                    this.getBaseItem().getLength(), this.getRotation())) {
                 oldHabbos.addAll(room.getHabbosAt(tile));
                 oldBots.addAll(room.getBotsAt(tile));
             }
 
-            for (RoomTile tile : room.getLayout().getTilesAt(oldLocation, this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation())) {
+            for (RoomTile tile : room.getLayout().getTilesAt(oldLocation, this.getBaseItem().getWidth(),
+                    this.getBaseItem().getLength(), this.getRotation())) {
                 newHabbos.addAll(room.getHabbosAt(tile));
                 newBots.addAll(room.getBotsAt(tile));
             }
@@ -440,41 +501,49 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
             oldBots.removeAll(newBots);
 
             for (Habbo habbo : oldHabbos) {
-                if (this.getBaseItem().getEffectM() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.M) && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
+                if (this.getBaseItem().getEffectM() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.M)
+                        && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
                     room.giveEffect(habbo, nextEffectM, -1);
                 }
 
-                if (this.getBaseItem().getEffectF() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.F) && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
+                if (this.getBaseItem().getEffectF() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.F)
+                        && habbo.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
                     room.giveEffect(habbo, nextEffectF, -1);
                 }
             }
 
             for (Habbo habbo : newHabbos) {
-                if (this.getBaseItem().getEffectM() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.M) && habbo.getRoomUnit().getEffectId() != this.getBaseItem().getEffectM()) {
+                if (this.getBaseItem().getEffectM() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.M)
+                        && habbo.getRoomUnit().getEffectId() != this.getBaseItem().getEffectM()) {
                     room.giveEffect(habbo, this.getBaseItem().getEffectM(), -1);
                 }
 
-                if (this.getBaseItem().getEffectF() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.F) && habbo.getRoomUnit().getEffectId() != this.getBaseItem().getEffectF()) {
+                if (this.getBaseItem().getEffectF() > 0 && habbo.getHabboInfo().getGender().equals(HabboGender.F)
+                        && habbo.getRoomUnit().getEffectId() != this.getBaseItem().getEffectF()) {
                     room.giveEffect(habbo, this.getBaseItem().getEffectF(), -1);
                 }
             }
 
             for (Bot bot : oldBots) {
-                if (this.getBaseItem().getEffectM() > 0 && bot.getGender().equals(HabboGender.M) && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
+                if (this.getBaseItem().getEffectM() > 0 && bot.getGender().equals(HabboGender.M)
+                        && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectM()) {
                     room.giveEffect(bot.getRoomUnit(), nextEffectM, -1);
                 }
 
-                if (this.getBaseItem().getEffectF() > 0 && bot.getGender().equals(HabboGender.F) && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
+                if (this.getBaseItem().getEffectF() > 0 && bot.getGender().equals(HabboGender.F)
+                        && bot.getRoomUnit().getEffectId() == this.getBaseItem().getEffectF()) {
                     room.giveEffect(bot.getRoomUnit(), nextEffectF, -1);
                 }
             }
 
             for (Bot bot : newBots) {
-                if (this.getBaseItem().getEffectM() > 0 && bot.getGender().equals(HabboGender.M) && bot.getRoomUnit().getEffectId() != this.getBaseItem().getEffectM()) {
+                if (this.getBaseItem().getEffectM() > 0 && bot.getGender().equals(HabboGender.M)
+                        && bot.getRoomUnit().getEffectId() != this.getBaseItem().getEffectM()) {
                     room.giveEffect(bot.getRoomUnit(), this.getBaseItem().getEffectM(), -1);
                 }
 
-                if (this.getBaseItem().getEffectF() > 0 && bot.getGender().equals(HabboGender.F) && bot.getRoomUnit().getEffectId() != this.getBaseItem().getEffectF()) {
+                if (this.getBaseItem().getEffectF() > 0 && bot.getGender().equals(HabboGender.F)
+                        && bot.getRoomUnit().getEffectId() != this.getBaseItem().getEffectF()) {
                     room.giveEffect(bot.getRoomUnit(), this.getBaseItem().getEffectF(), -1);
                 }
             }
@@ -487,7 +556,8 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
 
     @Override
     public String toString() {
-        return "ID: " + this.id + ", BaseID: " + this.getBaseItem().getId() + ", X: " + this.x + ", Y: " + this.y + ", Z: " + this.z + ", Extradata: " + this.extradata;
+        return "ID: " + this.id + ", BaseID: " + this.getBaseItem().getId() + ", X: " + this.x + ", Y: " + this.y
+                + ", Z: " + this.z + ", Extradata: " + this.extradata;
     }
 
     public boolean allowWiredResetState() {
@@ -510,12 +580,15 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
         isFromGift = fromGift;
     }
 
-    public boolean invalidatesToRoomKick() { return false; }
+    public boolean invalidatesToRoomKick() {
+        return false;
+    }
 
     public List<RoomTile> getOccupyingTiles(RoomLayout layout) {
         List<RoomTile> tiles = new ArrayList<>();
 
-        Rectangle rect = RoomLayout.getRectangle(this.getX(), this.getY(), this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation());
+        Rectangle rect = RoomLayout.getRectangle(this.getX(), this.getY(), this.getBaseItem().getWidth(),
+                this.getBaseItem().getLength(), this.getRotation());
 
         for (int i = rect.x; i < rect.x + rect.getWidth(); i++) {
             for (int j = rect.y; j < rect.y + rect.getHeight(); j++) {

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
@@ -9,6 +9,7 @@ import com.eu.habbo.messages.outgoing.catalog.*;
 import com.eu.habbo.messages.outgoing.catalog.marketplace.MarketplaceConfigurationMessageComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.HabboBroadcastMessageComposer;
 import com.eu.habbo.messages.outgoing.modtool.ModeratorInitMessageComposer;
+import com.eu.habbo.messages.outgoing.unknown.BuildersClubSubscriptionStatusMessageComposer;
 import com.eu.habbo.messages.outgoing.users.PerkAllowancesMessageComposer;
 import com.eu.habbo.messages.outgoing.users.UserRightsMessageComposer;
 import com.eu.habbo.plugin.events.users.UserRankChangedEvent;
@@ -275,7 +276,8 @@ public class HabboManager {
             habbo.getHabboInfo().run();
 
             habbo.getClient().sendResponse(new CatalogPublishedMessageComposer());
-            habbo.getClient().sendResponse(new BuildersClubFurniCountMessageComposer(0));
+            habbo.getClient().sendResponse(new BuildersClubSubscriptionStatusMessageComposer(habbo));
+            habbo.getClient().sendResponse(new BuildersClubFurniCountMessageComposer(habbo));
             habbo.getClient().sendResponse(new BundleDiscountRulesetMessageComposer());
             habbo.getClient().sendResponse(new MarketplaceConfigurationMessageComposer());
             habbo.getClient().sendResponse(new GiftWrappingConfigurationMessageComposer());

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
@@ -31,7 +31,7 @@ public class HabboManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboManager.class);
 
-    //Configuration. Loaded from database & updated accordingly.
+    // Configuration. Loaded from database & updated accordingly.
     public static String WELCOME_MESSAGE = "";
     public static boolean NAMECHANGE_ENABLED = false;
 
@@ -47,7 +47,8 @@ public class HabboManager {
 
     public static HabboInfo getOfflineHabboInfo(int id) {
         HabboInfo info = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE id = ? LIMIT 1")) {
             statement.setInt(1, id);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -64,7 +65,9 @@ public class HabboManager {
     public static HabboInfo getOfflineHabboInfo(String username) {
         HabboInfo info = null;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE username = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection
+                        .prepareStatement("SELECT * FROM users WHERE username = ? LIMIT 1")) {
             statement.setString(1, username);
 
             try (ResultSet set = statement.executeQuery()) {
@@ -107,7 +110,8 @@ public class HabboManager {
         int userId = 0;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT id FROM users WHERE auth_ticket = ? LIMIT 1")) {
+                PreparedStatement statement = connection
+                        .prepareStatement("SELECT id FROM users WHERE auth_ticket = ? LIMIT 1")) {
             statement.setString(1, sso);
             try (ResultSet s = statement.executeQuery()) {
                 if (s.next()) {
@@ -131,9 +135,9 @@ public class HabboManager {
             return null;
         }
 
-
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE auth_ticket = ? LIMIT 1")) {
+                PreparedStatement statement = connection
+                        .prepareStatement("SELECT * FROM users WHERE auth_ticket = ? LIMIT 1")) {
             statement.setString(1, sso);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -144,7 +148,8 @@ public class HabboManager {
                     }
 
                     if (!Emulator.debugging) {
-                        try (PreparedStatement stmt = connection.prepareStatement("UPDATE users SET auth_ticket = ? WHERE id = ? LIMIT 1")) {
+                        try (PreparedStatement stmt = connection
+                                .prepareStatement("UPDATE users SET auth_ticket = ? WHERE id = ? LIMIT 1")) {
                             stmt.setString(1, "");
                             stmt.setInt(2, habbo.getHabboInfo().getId());
                             stmt.execute();
@@ -194,9 +199,7 @@ public class HabboManager {
 
     public synchronized void dispose() {
 
-
-//
-
+        //
 
         LOGGER.info("Habbo Manager -> Disposed!");
     }
@@ -204,7 +207,9 @@ public class HabboManager {
     public ArrayList<HabboInfo> getCloneAccounts(Habbo habbo, int limit) {
         ArrayList<HabboInfo> habboInfo = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE ip_register = ? OR ip_current = ? AND id != ? ORDER BY id DESC LIMIT ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM users WHERE ip_register = ? OR ip_current = ? AND id != ? ORDER BY id DESC LIMIT ?")) {
             statement.setString(1, habbo.getHabboInfo().getIpRegister());
             statement.setString(2, habbo.getHabboInfo().getIpLogin());
             statement.setInt(3, habbo.getHabboInfo().getId());
@@ -225,7 +230,9 @@ public class HabboManager {
     public List<Map.Entry<Integer, String>> getNameChanges(int userId, int limit) {
         List<Map.Entry<Integer, String>> nameChanges = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT timestamp, new_name FROM namechange_log WHERE user_id = ? ORDER by timestamp DESC LIMIT ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT timestamp, new_name FROM namechange_log WHERE user_id = ? ORDER by timestamp DESC LIMIT ?")) {
             statement.setInt(1, userId);
             statement.setInt(2, limit);
             try (ResultSet set = statement.executeQuery()) {
@@ -240,7 +247,6 @@ public class HabboManager {
         return nameChanges;
     }
 
-
     public void setRank(int userId, int rankId) throws Exception {
         Habbo habbo = this.getHabbo(userId);
 
@@ -253,7 +259,7 @@ public class HabboManager {
             if (!oldRank.getBadge().isEmpty()) {
                 habbo.deleteBadge(habbo.getInventory().getBadgesComponent().getBadge(oldRank.getBadge()));
             }
-            if(oldRank.getRoomEffect() > 0) {
+            if (oldRank.getRoomEffect() > 0) {
                 habbo.getInventory().getEffectsComponent().effects.remove(oldRank.getRoomEffect());
             }
 
@@ -263,8 +269,9 @@ public class HabboManager {
                 habbo.addBadge(newRank.getBadge());
             }
 
-            if(newRank.getRoomEffect() > 0) {
-                habbo.getInventory().getEffectsComponent().createRankEffect(habbo.getHabboInfo().getRank().getRoomEffect());
+            if (newRank.getRoomEffect() > 0) {
+                habbo.getInventory().getEffectsComponent()
+                        .createRankEffect(habbo.getHabboInfo().getRank().getRoomEffect());
             }
 
             habbo.getClient().sendResponse(new UserRightsMessageComposer(habbo));
@@ -282,9 +289,12 @@ public class HabboManager {
             habbo.getClient().sendResponse(new MarketplaceConfigurationMessageComposer());
             habbo.getClient().sendResponse(new GiftWrappingConfigurationMessageComposer());
             habbo.getClient().sendResponse(new RecyclerPrizesMessageComposer());
-            habbo.alert(Emulator.getTexts().getValue("commands.generic.cmd_give_rank.new_rank").replace("id", newRank.getName()));
+            habbo.alert(Emulator.getTexts().getValue("commands.generic.cmd_give_rank.new_rank").replace("id",
+                    newRank.getName()));
         } else {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users SET `rank` = ? WHERE id = ? LIMIT 1")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection
+                            .prepareStatement("UPDATE users SET `rank` = ? WHERE id = ? LIMIT 1")) {
                 statement.setInt(1, rankId);
                 statement.setInt(2, userId);
                 statement.execute();
@@ -301,7 +311,9 @@ public class HabboManager {
         if (habbo != null) {
             habbo.giveCredits(credits);
         } else {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection
+                            .prepareStatement("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1")) {
                 statement.setInt(1, credits);
                 statement.setInt(2, userId);
                 statement.execute();

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -106,6 +106,8 @@ public class HabboStats implements Runnable {
     private Integer buildersClubFurniCountCache;
     private int buildersClubFurniLimit;
     private int buildersClubMaxFurniLimit;
+    private final Object buildersClubReservationLock = new Object();
+    private int inflightBuildersClubPlacements = 0;
 
     private HabboStats(ResultSet set, HabboInfo habboInfo) throws SQLException {
         this.cache = new THashMap<>(1000);
@@ -709,6 +711,42 @@ public class HabboStats implements Runnable {
 
         this.buildersClubFurniCountCache = count;
         return count;
+    }
+
+    /**
+     * Atomically checks the Builder's Club furni limit and reserves a slot for an in-flight
+     * placement. Must be paired with exactly one {@link #releaseBuildersClubSlot()} call on
+     * every code path that follows a successful reservation (both success and failure).
+     *
+     * @return true if a slot was reserved, false if the user is at/over the limit or BC is not active
+     */
+    public boolean tryReserveBuildersClubSlot() {
+        synchronized (this.buildersClubReservationLock) {
+            int limit = this.getBuildersClubFurniLimit();
+            if (limit <= 0) {
+                return false;
+            }
+
+            int effectiveCount = this.getBuildersClubFurniCount() + this.inflightBuildersClubPlacements;
+            if (effectiveCount >= limit) {
+                return false;
+            }
+
+            this.inflightBuildersClubPlacements++;
+            return true;
+        }
+    }
+
+    /**
+     * Releases a previously reserved Builder's Club placement slot. Safe to call on both
+     * success (committed to DB) and failure (rolled back) paths. Never decrements below zero.
+     */
+    public void releaseBuildersClubSlot() {
+        synchronized (this.buildersClubReservationLock) {
+            if (this.inflightBuildersClubPlacements > 0) {
+                this.inflightBuildersClubPlacements--;
+            }
+        }
     }
 
     public int getPastTimeAsBuildersClub() {

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -12,6 +12,7 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.rooms.RoomTrade;
 import com.eu.habbo.habbohotel.users.cache.HabboOfferPurchase;
 import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionCreatedEvent;
 import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionExtendedEvent;
 import gnu.trove.list.array.TIntArrayList;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class HabboStats implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboStats.class);
+    private static volatile Boolean usersSettingsHasBuildersClubLimitColumns;
 
     public final TIntArrayList secretRecipes;
     public final HabboNavigatorWindowSettings navigatorWindowSettings;
@@ -101,6 +103,9 @@ public class HabboStats implements Runnable {
     public int hcGiftsClaimed;
     public int hcMessageLastModified = Emulator.getIntUnixTimestamp();
     public THashSet<Subscription> subscriptions;
+    private Integer buildersClubFurniCountCache;
+    private int buildersClubFurniLimit;
+    private int buildersClubMaxFurniLimit;
 
     private HabboStats(ResultSet set, HabboInfo habboInfo) throws SQLException {
         this.cache = new THashMap<>(1000);
@@ -155,8 +160,11 @@ public class HabboStats implements Runnable {
         this.maxRooms = set.getInt("max_rooms");
         this.lastHCPayday = set.getInt("last_hc_payday");
         this.hcGiftsClaimed = set.getInt("hc_gifts_claimed");
+        this.buildersClubFurniLimit = readOptionalInt(set, "builders_club_furni_limit", 0);
+        this.buildersClubMaxFurniLimit = readOptionalInt(set, "builders_club_max_furni_limit", this.buildersClubFurniLimit);
 
         this.nuxReward = this.nux;
+        this.buildersClubFurniCountCache = null;
 
         this.subscriptions = Emulator.getGameEnvironment().getSubscriptionManager().getSubscriptionsForUser(this.habboInfo.getId());
 
@@ -327,7 +335,11 @@ public class HabboStats implements Runnable {
         int onlineTime = Emulator.getIntUnixTimestamp() - onlineTimeLast;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET achievement_score = ?, respects_received = ?, respects_given = ?, daily_respect_points = ?, block_following = ?, block_friendrequests = ?, online_time = online_time + ?, guild_id = ?, daily_pet_respect_points = ?, club_expire_timestamp = ?, login_streak = ?, rent_space_id = ?, rent_space_endtime = ?, volume_system = ?, volume_furni = ?, volume_trax = ?, block_roominvites = ?, old_chat = ?, block_camera_follow = ?, chat_color = ?, hof_points = ?, block_alerts = ?, talent_track_citizenship_level = ?, talent_track_helpers_level = ?, ignore_bots = ?, ignore_pets = ?, nux = ?, mute_end_timestamp = ?, allow_name_change = ?, perk_trade = ?, can_trade = ?, `forums_post_count` = ?, ui_flags = ?, has_gotten_default_saved_searches = ?, max_friends = ?, max_rooms = ?, last_hc_payday = ?, hc_gifts_claimed = ? WHERE user_id = ? LIMIT 1")) {
+            boolean hasBuildersClubLimitColumns = hasUsersSettingsBuildersClubLimitColumns(connection);
+            String sql = "UPDATE users_settings SET achievement_score = ?, respects_received = ?, respects_given = ?, daily_respect_points = ?, block_following = ?, block_friendrequests = ?, online_time = online_time + ?, guild_id = ?, daily_pet_respect_points = ?, club_expire_timestamp = ?, login_streak = ?, rent_space_id = ?, rent_space_endtime = ?, volume_system = ?, volume_furni = ?, volume_trax = ?, block_roominvites = ?, old_chat = ?, block_camera_follow = ?, chat_color = ?, hof_points = ?, block_alerts = ?, talent_track_citizenship_level = ?, talent_track_helpers_level = ?, ignore_bots = ?, ignore_pets = ?, nux = ?, mute_end_timestamp = ?, allow_name_change = ?, perk_trade = ?, can_trade = ?, `forums_post_count` = ?, ui_flags = ?, has_gotten_default_saved_searches = ?, max_friends = ?, max_rooms = ?, last_hc_payday = ?, hc_gifts_claimed = ?"
+                    + (hasBuildersClubLimitColumns ? ", builders_club_furni_limit = ?, builders_club_max_furni_limit = ?" : "")
+                    + " WHERE user_id = ? LIMIT 1";
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
                 statement.setInt(1, this.achievementScore);
                 statement.setInt(2, this.respectPointsReceived);
                 statement.setInt(3, this.respectPointsGiven);
@@ -366,7 +378,12 @@ public class HabboStats implements Runnable {
                 statement.setInt(36, this.maxRooms);
                 statement.setInt(37, this.lastHCPayday);
                 statement.setInt(38, this.hcGiftsClaimed);
-                statement.setInt(39, this.habboInfo.getId());
+                int parameterIndex = 39;
+                if (hasBuildersClubLimitColumns) {
+                    statement.setInt(parameterIndex++, this.getStoredBuildersClubFurniLimit());
+                    statement.setInt(parameterIndex++, this.getStoredBuildersClubMaxFurniLimit());
+                }
+                statement.setInt(parameterIndex, this.habboInfo.getId());
                 
                 statement.executeUpdate();
             }
@@ -475,6 +492,22 @@ public class HabboStats implements Runnable {
         return null;
     }
 
+    public Subscription getLatestSubscription(String subscriptionType) {
+        Subscription latest = null;
+
+        for (Subscription subscription : this.subscriptions) {
+            if (!subscription.getSubscriptionType().equalsIgnoreCase(subscriptionType)) {
+                continue;
+            }
+
+            if (latest == null || subscription.getTimestampEnd() > latest.getTimestampEnd()) {
+                latest = subscription;
+            }
+        }
+
+        return latest;
+    }
+
     public boolean hasSubscription(String subscriptionType) {
         Subscription subscription = getSubscription(subscriptionType);
         return subscription != null;
@@ -554,6 +587,142 @@ public class HabboStats implements Runnable {
         return hasSubscription(Subscription.HABBO_CLUB);
     }
 
+    public boolean hasActiveBuildersClub() {
+        return SubscriptionBuildersClub.isEnabled() && this.getBuildersClubSecondsRemaining() > 0;
+    }
+
+    public boolean hasEffectiveBuildersClub() {
+        return SubscriptionBuildersClub.isEnabled() && this.getBuildersClubSecondsRemainingWithGrace() > 0;
+    }
+
+    public Subscription getBuildersClubSubscription() {
+        return this.getLatestSubscription(Subscription.BUILDERS_CLUB);
+    }
+
+    public int getBuildersClubSecondsRemaining() {
+        Subscription subscription = this.getBuildersClubSubscription();
+        if (subscription == null) {
+            return 0;
+        }
+
+        return Math.max(0, subscription.getRemaining());
+    }
+
+    public int getBuildersClubSecondsRemainingWithGrace() {
+        Subscription subscription = this.getBuildersClubSubscription();
+        if (subscription == null) {
+            return 0;
+        }
+
+        return Math.max(0, subscription.getRemaining() + SubscriptionBuildersClub.GRACE_SECONDS);
+    }
+
+    public int getBuildersClubFurniLimit() {
+        if (!this.hasEffectiveBuildersClub()) {
+            return 0;
+        }
+
+        return this.getStoredBuildersClubFurniLimit();
+    }
+
+    public int getBuildersClubMaxFurniLimit() {
+        if (!this.hasEffectiveBuildersClub()) {
+            return 0;
+        }
+
+        return this.getStoredBuildersClubMaxFurniLimit();
+    }
+
+    public int getStoredBuildersClubFurniLimit() {
+        return Math.max(0, this.buildersClubFurniLimit);
+    }
+
+    public int getStoredBuildersClubMaxFurniLimit() {
+        return Math.max(this.buildersClubMaxFurniLimit, this.buildersClubFurniLimit);
+    }
+
+    public void setBuildersClubFurniLimit(int furniLimit) {
+        this.buildersClubFurniLimit = Math.max(0, furniLimit);
+        this.buildersClubMaxFurniLimit = Math.max(this.buildersClubMaxFurniLimit, this.buildersClubFurniLimit);
+    }
+
+    public void setBuildersClubMaxFurniLimit(int maxFurniLimit) {
+        this.buildersClubMaxFurniLimit = Math.max(0, maxFurniLimit);
+        if (this.buildersClubMaxFurniLimit < this.buildersClubFurniLimit) {
+            this.buildersClubMaxFurniLimit = this.buildersClubFurniLimit;
+        }
+    }
+
+    public void addBuildersClubFurniLimit(int furniLimitDelta) {
+        if (furniLimitDelta <= 0) {
+            return;
+        }
+
+        this.buildersClubFurniLimit = Math.max(0, this.buildersClubFurniLimit + furniLimitDelta);
+        this.buildersClubMaxFurniLimit = Math.max(this.buildersClubMaxFurniLimit, this.buildersClubFurniLimit);
+    }
+
+    public Subscription createBuildersClubBoxSubscription(int duration) {
+        Subscription subscription = this.createSubscription(Subscription.BUILDERS_CLUB, duration);
+        if (subscription == null) {
+            return null;
+        }
+
+        this.addBuildersClubFurniLimit(SubscriptionBuildersClub.BOX_FURNI_LIMIT_INCREMENT);
+        Emulator.getThreading().run(this);
+
+        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.habboInfo.getId());
+        if (habbo != null && habbo.getClient() != null) {
+            SubscriptionBuildersClub.pushCatalogState(habbo);
+        }
+
+        return subscription;
+    }
+
+    public void invalidateBuildersClubFurniCount() {
+        this.buildersClubFurniCountCache = null;
+    }
+
+    public int getBuildersClubFurniCount() {
+        if (this.buildersClubFurniCountCache == null) {
+            this.buildersClubFurniCountCache = this.refreshBuildersClubFurniCount();
+        }
+
+        return this.buildersClubFurniCountCache;
+    }
+
+    public int refreshBuildersClubFurniCount() {
+        int count = 0;
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM items WHERE user_id = ? AND id >= ? AND room_id > 0")) {
+            statement.setInt(1, this.habboInfo.getId());
+            statement.setInt(2, SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START);
+
+            try (ResultSet set = statement.executeQuery()) {
+                if (set.next()) {
+                    count = set.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to refresh Builder's Club furni count for user {}", this.habboInfo.getId(), e);
+        }
+
+        this.buildersClubFurniCountCache = count;
+        return count;
+    }
+
+    public int getPastTimeAsBuildersClub() {
+        int pastTimeAsBuildersClub = 0;
+        for (Subscription subscription : this.subscriptions) {
+            if (subscription.getSubscriptionType().equalsIgnoreCase(Subscription.BUILDERS_CLUB)) {
+                pastTimeAsBuildersClub += subscription.getDuration() - Math.max(subscription.getRemaining(), 0);
+            }
+        }
+
+        return pastTimeAsBuildersClub;
+    }
+
     public int getPastTimeAsClub() {
         int pastTimeAsHC = 0;
         for(Subscription subs : this.subscriptions) {
@@ -584,13 +753,33 @@ public class HabboStats implements Runnable {
     }
 
     public void addPurchase(CatalogItem item) {
-        if (!this.recentPurchases.containsKey(item.getId())) {
-            this.recentPurchases.put(item.getId(), item);
+        int wireId = item.getWireId();
+        if (!this.recentPurchases.containsKey(wireId)) {
+            this.recentPurchases.put(wireId, item);
         }
     }
 
     public THashMap<Integer, CatalogItem> getRecentPurchases() {
         return this.recentPurchases;
+    }
+
+    public CatalogItem getRecentPurchaseByWireId(int wireId) {
+        CatalogItem item = this.recentPurchases.get(wireId);
+        if (item != null) {
+            return item;
+        }
+
+        for (CatalogItem recentPurchase : this.recentPurchases.values()) {
+            if (recentPurchase == null) {
+                continue;
+            }
+
+            if (recentPurchase.getWireId() == wireId || recentPurchase.getId() == wireId) {
+                return recentPurchase;
+            }
+        }
+
+        return null;
     }
 
     public void disposeRecentPurchases() {
@@ -795,5 +984,35 @@ public class HabboStats implements Runnable {
 
     public void addHabboOfferPurchase(HabboOfferPurchase offerPurchase) {
         this.offerCache.put(offerPurchase.getOfferId(), offerPurchase);
+    }
+
+    private static int readOptionalInt(ResultSet set, String column, int fallback) {
+        try {
+            return set.getInt(column);
+        } catch (SQLException e) {
+            return fallback;
+        }
+    }
+
+    private static boolean hasUsersSettingsBuildersClubLimitColumns(Connection connection) {
+        if (usersSettingsHasBuildersClubLimitColumns != null) {
+            return usersSettingsHasBuildersClubLimitColumns;
+        }
+
+        synchronized (HabboStats.class) {
+            if (usersSettingsHasBuildersClubLimitColumns != null) {
+                return usersSettingsHasBuildersClubLimitColumns;
+            }
+
+            boolean hasColumns = false;
+            try (ResultSet set = connection.getMetaData().getColumns(connection.getCatalog(), null, "users_settings", "builders_club_furni_limit")) {
+                hasColumns = set.next();
+            } catch (SQLException e) {
+                LOGGER.warn("Failed to inspect users_settings for Builder's Club limit columns", e);
+            }
+
+            usersSettingsHasBuildersClubLimitColumns = hasColumns;
+            return hasColumns;
+        }
     }
 }

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -695,9 +695,8 @@ public class HabboStats implements Runnable {
         int count = 0;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM items WHERE user_id = ? AND id >= ? AND room_id > 0")) {
+             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM items WHERE user_id = ? AND is_builders_club = 1 AND room_id > 0")) {
             statement.setInt(1, this.habboInfo.getId());
-            statement.setInt(2, SubscriptionBuildersClub.BUILDERS_CLUB_ITEM_ID_START);
 
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -593,8 +593,22 @@ public class HabboStats implements Runnable {
         return SubscriptionBuildersClub.isEnabled() && this.getBuildersClubSecondsRemaining() > 0;
     }
 
+    /**
+     * Returns true when the user is on a Builder's Club free trial — i.e. BC is enabled,
+     * free trials are enabled, they have a stored furni limit (set by setupFreeTrial), but
+     * they hold no active subscription.  Free-trial users can place items when alone in the
+     * room (the visitor-blocking check in BuildersClubPlacementSupport still applies).
+     */
+    public boolean isOnBuildersClubFreeTrial() {
+        return SubscriptionBuildersClub.isEnabled()
+                && SubscriptionBuildersClub.FREE_TRIAL_ENABLED
+                && this.getBuildersClubSubscription() == null
+                && this.getStoredBuildersClubFurniLimit() > 0;
+    }
+
     public boolean hasEffectiveBuildersClub() {
-        return SubscriptionBuildersClub.isEnabled() && this.getBuildersClubSecondsRemainingWithGrace() > 0;
+        return SubscriptionBuildersClub.isEnabled()
+                && (this.getBuildersClubSecondsRemainingWithGrace() > 0 || this.isOnBuildersClubFreeTrial());
     }
 
     public Subscription getBuildersClubSubscription() {

--- a/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/Subscription.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/Subscription.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
  */
 public class Subscription {
     public static final String HABBO_CLUB = "HABBO_CLUB";
+    public static final String BUILDERS_CLUB = "BUILDERS_CLUB";
 
     private final int id;
     private final int userId;

--- a/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionBuildersClub.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionBuildersClub.java
@@ -90,7 +90,7 @@ public class SubscriptionBuildersClub extends Subscription {
         return ENABLED;
     }
 
-    public static boolean isBuildersClubItemId(int itemId) {
+    public static boolean isBuildersClubVisibleId(int itemId) {
         return itemId >= BUILDERS_CLUB_ITEM_ID_START;
     }
 
@@ -162,9 +162,8 @@ public class SubscriptionBuildersClub extends Subscription {
             }
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE user_id = ? AND id >= ?")) {
-                statement.setInt(1, userId);
-                statement.setInt(2, BUILDERS_CLUB_ITEM_ID_START);
+                 PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE user_id = ? AND is_builders_club = 1")) {
+            statement.setInt(1, userId);
                 statement.executeUpdate();
             } catch (SQLException e) {
                 LOGGER.error("Failed to clean up Builder's Club items for user {}", userId, e);

--- a/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionBuildersClub.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionBuildersClub.java
@@ -36,8 +36,12 @@ public class SubscriptionBuildersClub extends Subscription {
     public static String ACHIEVEMENT_NAME = "BuildersClub";
     public static String BUY_MEMBERSHIP_PAGE = "";
     public static String TRY_PAGE = "";
+    public static boolean FREE_TRIAL_ENABLED = true;
+    public static int FREE_TRIAL_LIMIT = 50;
+    public static int EXPIRY_WARNING_SECONDS = 86400;
 
-    public SubscriptionBuildersClub(Integer id, Integer userId, String subscriptionType, Integer timestampStart, Integer duration, Boolean active) {
+    public SubscriptionBuildersClub(Integer id, Integer userId, String subscriptionType, Integer timestampStart,
+            Integer duration, Boolean active) {
         super(id, userId, subscriptionType, timestampStart, duration, active);
     }
 
@@ -48,9 +52,10 @@ public class SubscriptionBuildersClub extends Subscription {
         progressAchievement(this.getUserId());
 
         if (habbo != null && habbo.getClient() != null) {
-            habbo.getClient().sendResponse(new NotificationDialogMessageComposer(hasPreviousBuildersClubSubscription(habbo.getHabboStats())
-                    ? BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_RENEWED.key
-                    : BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_MADE.key));
+            habbo.getClient().sendResponse(
+                    new NotificationDialogMessageComposer(hasPreviousBuildersClubSubscription(habbo.getHabboStats())
+                            ? BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_RENEWED.key
+                            : BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_MADE.key));
             pushCatalogState(habbo);
             sendRoomLockStateBubble(habbo);
         }
@@ -63,7 +68,8 @@ public class SubscriptionBuildersClub extends Subscription {
         progressAchievement(this.getUserId());
 
         if (habbo != null && habbo.getClient() != null) {
-            habbo.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXTENDED.key));
+            habbo.getClient().sendResponse(
+                    new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXTENDED.key));
             pushCatalogState(habbo);
             sendRoomLockStateBubble(habbo);
         }
@@ -75,7 +81,8 @@ public class SubscriptionBuildersClub extends Subscription {
 
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.getUserId());
         if (habbo != null && habbo.getClient() != null) {
-            habbo.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXPIRED.key));
+            habbo.getClient().sendResponse(
+                    new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXPIRED.key));
         }
 
         applyExpiryAction(this.getUserId());
@@ -130,12 +137,14 @@ public class SubscriptionBuildersClub extends Subscription {
 
     public static void notifyBuildersClubVisitorDenied(Room room, Habbo guest) {
         if (guest != null && guest.getClient() != null) {
-            guest.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_GUEST.key));
+            guest.getClient().sendResponse(
+                    new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_GUEST.key));
         }
 
         Habbo owner = Emulator.getGameEnvironment().getHabboManager().getHabbo(room.getOwnerId());
         if (owner != null && owner.getClient() != null) {
-            owner.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_OWNER.key));
+            owner.getClient().sendResponse(
+                    new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_OWNER.key));
         }
     }
 
@@ -151,8 +160,46 @@ public class SubscriptionBuildersClub extends Subscription {
         habbo.getClient().sendResponse(new NotificationDialogMessageComposer(
                 habbo.getHabboStats().getBuildersClubSecondsRemaining() > 0
                         ? BubbleAlertKeys.BUILDERS_CLUB_ROOM_UNLOCKED.key
-                        : BubbleAlertKeys.BUILDERS_CLUB_ROOM_LOCKED.key
-        ));
+                        : BubbleAlertKeys.BUILDERS_CLUB_ROOM_LOCKED.key));
+    }
+
+    /**
+     * Sends a "membership about to expire" popup if the user has an active BC
+     * subscription with less than {@link #EXPIRY_WARNING_SECONDS} remaining.
+     * Safe to call on every login; it only fires the alert once per session.
+     */
+    public static void checkExpiryWarning(Habbo habbo) {
+        if (habbo == null || habbo.getClient() == null) {
+            return;
+        }
+
+        int remaining = habbo.getHabboStats().getBuildersClubSecondsRemaining();
+        if (remaining > 0 && remaining <= EXPIRY_WARNING_SECONDS) {
+            habbo.getClient().sendResponse(
+                    new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXPIRES.key));
+        }
+    }
+
+    /**
+     * Sets up the free-trial defaults for a brand-new user.
+     * Gives them a furni limit of {@link #FREE_TRIAL_LIMIT} with no active
+     * subscription time, which puts them in "trial mode" (visitors block
+     * placement).
+     */
+    public static void setupFreeTrial(Habbo habbo) {
+        if (!FREE_TRIAL_ENABLED || habbo == null) {
+            return;
+        }
+
+        HabboStats stats = habbo.getHabboStats();
+        if (stats.getStoredBuildersClubFurniLimit() > 0) {
+            return; // already has a limit set (e.g. returning user with DB row)
+        }
+
+        stats.setBuildersClubFurniLimit(FREE_TRIAL_LIMIT);
+        Emulator.getThreading().run(stats);
+        LOGGER.info("Set up Builder's Club free trial for new user {} with limit {}",
+                habbo.getHabboInfo().getUsername(), FREE_TRIAL_LIMIT);
     }
 
     public static void applyExpiryAction(int userId) {
@@ -162,8 +209,9 @@ public class SubscriptionBuildersClub extends Subscription {
             }
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE user_id = ? AND is_builders_club = 1")) {
-            statement.setInt(1, userId);
+                    PreparedStatement statement = connection
+                            .prepareStatement("DELETE FROM items WHERE user_id = ? AND is_builders_club = 1")) {
+                statement.setInt(1, userId);
                 statement.executeUpdate();
             } catch (SQLException e) {
                 LOGGER.error("Failed to clean up Builder's Club items for user {}", userId, e);
@@ -196,7 +244,8 @@ public class SubscriptionBuildersClub extends Subscription {
             return;
         }
 
-        Achievement achievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement(ACHIEVEMENT_NAME);
+        Achievement achievement = Emulator.getGameEnvironment().getAchievementManager()
+                .getAchievement(ACHIEVEMENT_NAME);
         if (achievement == null) {
             return;
         }

--- a/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionBuildersClub.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionBuildersClub.java
@@ -1,0 +1,217 @@
+package com.eu.habbo.habbohotel.users.subscriptions;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.achievements.Achievement;
+import com.eu.habbo.habbohotel.achievements.AchievementManager;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboStats;
+import com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
+import com.eu.habbo.messages.outgoing.generic.alerts.NotificationDialogMessageComposer;
+import com.eu.habbo.messages.outgoing.unknown.BuildersClubSubscriptionStatusMessageComposer;
+import com.eu.habbo.messages.outgoing.users.PerkAllowancesMessageComposer;
+import gnu.trove.map.hash.THashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class SubscriptionBuildersClub extends Subscription {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionBuildersClub.class);
+
+    public static final int BUILDERS_CLUB_ITEM_ID_START = 0x7FFF0000;
+
+    public static boolean ENABLED = false;
+    public static int FURNI_LIMIT = 75;
+    public static int MAX_FURNI_LIMIT = 250;
+    public static int BOX_FURNI_LIMIT_INCREMENT = 750;
+    public static int GRACE_SECONDS = 0;
+    public static boolean GROUP_ROOM_PLACEMENT_ENABLED = false;
+    public static String EXPIRY_ACTION = "none";
+    public static String ACHIEVEMENT_NAME = "BuildersClub";
+    public static String BUY_MEMBERSHIP_PAGE = "";
+    public static String TRY_PAGE = "";
+
+    public SubscriptionBuildersClub(Integer id, Integer userId, String subscriptionType, Integer timestampStart, Integer duration, Boolean active) {
+        super(id, userId, subscriptionType, timestampStart, duration, active);
+    }
+
+    @Override
+    public void onCreated() {
+        super.onCreated();
+        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.getUserId());
+        progressAchievement(this.getUserId());
+
+        if (habbo != null && habbo.getClient() != null) {
+            habbo.getClient().sendResponse(new NotificationDialogMessageComposer(hasPreviousBuildersClubSubscription(habbo.getHabboStats())
+                    ? BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_RENEWED.key
+                    : BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_MADE.key));
+            pushCatalogState(habbo);
+            sendRoomLockStateBubble(habbo);
+        }
+    }
+
+    @Override
+    public void onExtended(int duration) {
+        super.onExtended(duration);
+        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.getUserId());
+        progressAchievement(this.getUserId());
+
+        if (habbo != null && habbo.getClient() != null) {
+            habbo.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXTENDED.key));
+            pushCatalogState(habbo);
+            sendRoomLockStateBubble(habbo);
+        }
+    }
+
+    @Override
+    public void onExpired() {
+        super.onExpired();
+
+        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.getUserId());
+        if (habbo != null && habbo.getClient() != null) {
+            habbo.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_MEMBERSHIP_EXPIRED.key));
+        }
+
+        applyExpiryAction(this.getUserId());
+
+        if (habbo != null && habbo.getClient() != null) {
+            pushCatalogState(habbo);
+            sendRoomLockStateBubble(habbo);
+        }
+    }
+
+    public static boolean isEnabled() {
+        return ENABLED;
+    }
+
+    public static boolean isBuildersClubItemId(int itemId) {
+        return itemId >= BUILDERS_CLUB_ITEM_ID_START;
+    }
+
+    public static boolean hasVisitorsBlockingPlacement(Room room, Habbo owner) {
+        for (Habbo habbo : room.getHabbos()) {
+            if (habbo == null || habbo == owner) {
+                continue;
+            }
+
+            if (!habbo.hasPermission(Permission.ACC_MODTOOL_ROOM_INFO)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean shouldLockRoom(Room room) {
+        if (!"lock".equalsIgnoreCase(EXPIRY_ACTION) || room == null || !room.hasBuildersClubItems()) {
+            return false;
+        }
+
+        HabboInfo owner = Emulator.getGameEnvironment().getHabboManager().getHabboInfo(room.getOwnerId());
+        return owner != null && owner.getHabboStats().getBuildersClubSecondsRemaining() <= 0;
+    }
+
+    public static void pushCatalogState(Habbo habbo) {
+        if (habbo == null || habbo.getClient() == null) {
+            return;
+        }
+
+        habbo.getHabboStats().invalidateBuildersClubFurniCount();
+        habbo.getClient().sendResponse(new BuildersClubSubscriptionStatusMessageComposer(habbo));
+        habbo.getClient().sendResponse(new BuildersClubFurniCountMessageComposer(habbo));
+        habbo.getClient().sendResponse(new PerkAllowancesMessageComposer(habbo));
+    }
+
+    public static void notifyBuildersClubVisitorDenied(Room room, Habbo guest) {
+        if (guest != null && guest.getClient() != null) {
+            guest.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_GUEST.key));
+        }
+
+        Habbo owner = Emulator.getGameEnvironment().getHabboManager().getHabbo(room.getOwnerId());
+        if (owner != null && owner.getClient() != null) {
+            owner.getClient().sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_OWNER.key));
+        }
+    }
+
+    public static void sendRoomLockStateBubble(Habbo habbo) {
+        if (habbo == null || habbo.getClient() == null) {
+            return;
+        }
+
+        if (habbo.getHabboStats().getBuildersClubFurniCount() <= 0) {
+            return;
+        }
+
+        habbo.getClient().sendResponse(new NotificationDialogMessageComposer(
+                habbo.getHabboStats().getBuildersClubSecondsRemaining() > 0
+                        ? BubbleAlertKeys.BUILDERS_CLUB_ROOM_UNLOCKED.key
+                        : BubbleAlertKeys.BUILDERS_CLUB_ROOM_LOCKED.key
+        ));
+    }
+
+    public static void applyExpiryAction(int userId) {
+        if ("pickup".equalsIgnoreCase(EXPIRY_ACTION)) {
+            for (Room room : Emulator.getGameEnvironment().getRoomManager().getActiveRooms()) {
+                room.pickUpBuildersClubItems(userId, null);
+            }
+
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                 PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE user_id = ? AND id >= ?")) {
+                statement.setInt(1, userId);
+                statement.setInt(2, BUILDERS_CLUB_ITEM_ID_START);
+                statement.executeUpdate();
+            } catch (SQLException e) {
+                LOGGER.error("Failed to clean up Builder's Club items for user {}", userId, e);
+            }
+        }
+
+        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
+        if (habbo != null) {
+            habbo.getHabboStats().invalidateBuildersClubFurniCount();
+        }
+    }
+
+    private static boolean hasPreviousBuildersClubSubscription(HabboStats stats) {
+        int count = 0;
+        for (Subscription subscription : stats.subscriptions) {
+            if (Subscription.BUILDERS_CLUB.equalsIgnoreCase(subscription.getSubscriptionType())) {
+                count++;
+                if (count > 1) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void progressAchievement(int userId) {
+        HabboInfo habboInfo = Emulator.getGameEnvironment().getHabboManager().getHabboInfo(userId);
+        if (habboInfo == null) {
+            return;
+        }
+
+        Achievement achievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement(ACHIEVEMENT_NAME);
+        if (achievement == null) {
+            return;
+        }
+
+        int currentProgress = habboInfo.getHabboStats().getAchievementProgress(achievement);
+        if (currentProgress == -1) {
+            currentProgress = 0;
+        }
+
+        int progressToSet = (int) Math.ceil(habboInfo.getHabboStats().getPastTimeAsBuildersClub() / 2678400.0);
+        int toIncrease = Math.max(progressToSet - currentProgress, 0);
+
+        if (toIncrease > 0) {
+            AchievementManager.progressAchievement(userId, achievement, toIncrease);
+        }
+    }
+}

--- a/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionManager.java
@@ -28,6 +28,7 @@ public class SubscriptionManager {
 
     public void init() {
         this.types.put(Subscription.HABBO_CLUB, SubscriptionHabboClub.class);
+        this.types.put(Subscription.BUILDERS_CLUB, SubscriptionBuildersClub.class);
     }
 
     public void addSubscriptionType(String type, Class<? extends Subscription> clazz) {

--- a/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -234,6 +234,8 @@ public class PacketManager {
         this.registerHandler(Incoming.GetMarketplaceConfigEvent, RequestMarketplaceConfigEvent.class);
         this.registerHandler(Incoming.GetCatalogIndexEvent, GetCatalogIndexEvent.class);
         this.registerHandler(Incoming.BuildersClubQueryFurniCountMessageEvent, BuildersClubQueryFurniCountMessageEvent.class);
+        this.registerHandler(Incoming.BuildersClubPlaceRoomItemMessageEvent, BuildersClubPlaceRoomItemMessageEvent.class);
+        this.registerHandler(Incoming.BuildersClubPlaceWallItemMessageEvent, BuildersClubPlaceWallItemMessageEvent.class);
         this.registerHandler(Incoming.GetCatalogPageEvent, GetCatalogPageEvent.class);
         this.registerHandler(Incoming.PurchaseFromCatalogAsGiftEvent, PurchaseFromCatalogAsGiftEvent.class);
         this.registerHandler(Incoming.PurchaseFromCatalogEvent, PurchaseFromCatalogEvent.class);

--- a/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -14,6 +14,7 @@ public class Incoming {
     public static final int SetClothingChangeDataMessageEvent = 924;
     public static final int SetMannequinFigureEvent = 2209;
     public static final int GetCatalogPageEvent = 412;
+    public static final int BuildersClubPlaceWallItemMessageEvent = 462;
     public static final int GetSelectedBadgesMessageEvent = 2091;
     public static final int RemoveBotFromFlatMessageEvent = 3323;
     public static final int HorseRideEvent = 1036;
@@ -55,6 +56,7 @@ public class Incoming {
     public static final int RequestRoomPropertySetEvent = 711;
     public static final int PopularRoomsSearchMessageEvent = 2758;
     public static final int GetModeratorRoomInfoMessageEvent = 707;
+    public static final int BuildersClubPlaceRoomItemMessageEvent = 1051;
     public static final int RequestFriendMessageEvent = 3157;
     public static final int RecycleItemsMessageEvent = 2771;
     public static final int GetUserFlatCatsMessageEvent = 3027; //1371;

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
@@ -23,34 +23,45 @@ public class BuildersClubPlaceRoomItemMessageEvent extends MessageHandler {
             return;
         }
 
-        RoomTile tile = placement.room().getLayout().getTile(x, y);
-        if (tile == null) {
-            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_tile"));
-            return;
-        }
+        // validate() reserved an in-flight slot on success; release it on every path below.
+        boolean released = false;
+        try {
+            RoomTile tile = placement.room().getLayout().getTile(x, y);
+            if (tile == null) {
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_tile"));
+                return;
+            }
 
-        HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
-        if (item == null) {
-            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
-            return;
-        }
+            HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
+            if (item == null) {
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
+                return;
+            }
 
-        FurnitureMovementError error = placement.room().canPlaceFurnitureAt(item, this.client.getHabbo(), tile, rotation);
-        if (!error.equals(FurnitureMovementError.NONE)) {
-            com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
-            this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
-            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
-            return;
-        }
+            FurnitureMovementError error = placement.room().canPlaceFurnitureAt(item, this.client.getHabbo(), tile, rotation);
+            if (!error.equals(FurnitureMovementError.NONE)) {
+                com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+                this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
+                return;
+            }
 
-        error = placement.room().placeFloorFurniAt(item, tile, rotation, this.client.getHabbo());
-        if (!error.equals(FurnitureMovementError.NONE)) {
-            com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
-            this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
-            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
-            return;
-        }
+            error = placement.room().placeFloorFurniAt(item, tile, rotation, this.client.getHabbo());
+            if (!error.equals(FurnitureMovementError.NONE)) {
+                com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+                this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
+                return;
+            }
 
-        BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+            // Release the reservation first so sendUpdatedState sees the fresh post-commit count.
+            this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
+            released = true;
+            BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+        } finally {
+            if (!released) {
+                this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
+            }
+        }
     }
 }

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
+import com.eu.habbo.messages.outgoing.generic.alerts.NotificationDialogMessageComposer;
+
+public class BuildersClubPlaceRoomItemMessageEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        int pageId = this.packet.readInt();
+        int offerId = this.packet.readInt();
+        String extraData = this.packet.readString();
+        short x = this.packet.readInt().shortValue();
+        short y = this.packet.readInt().shortValue();
+        int rotation = this.packet.readInt();
+
+        BuildersClubPlacementSupport.ValidatedPlacement placement = BuildersClubPlacementSupport.validate(this.client, pageId, offerId, FurnitureType.FLOOR);
+        if (placement == null) {
+            return;
+        }
+
+        RoomTile tile = placement.room().getLayout().getTile(x, y);
+        if (tile == null) {
+            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_tile"));
+            return;
+        }
+
+        HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
+        if (item == null) {
+            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
+            return;
+        }
+
+        FurnitureMovementError error = placement.room().canPlaceFurnitureAt(item, this.client.getHabbo(), tile, rotation);
+        if (!error.equals(FurnitureMovementError.NONE)) {
+            com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+            this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
+            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
+            return;
+        }
+
+        error = placement.room().placeFloorFurniAt(item, tile, rotation, this.client.getHabbo());
+        if (!error.equals(FurnitureMovementError.NONE)) {
+            com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+            this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
+            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
+            return;
+        }
+
+        BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+    }
+}

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
@@ -2,9 +2,11 @@ package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.rooms.RoomState;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.catalog.BCPlacementWarningMessageComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.generic.alerts.NotificationDialogMessageComposer;
 
@@ -17,6 +19,14 @@ public class BuildersClubPlaceRoomItemMessageEvent extends MessageHandler {
         short x = this.packet.readInt().shortValue();
         short y = this.packet.readInt().shortValue();
         int rotation = this.packet.readInt();
+        boolean confirmHideRoom = this.packet.readBoolean();
+
+        // Check trial warning condition before validate() reserves a slot.
+        var earlyRoom = this.client.getHabbo().getHabboInfo().getCurrentRoom();
+        boolean shouldWarnTrial = !confirmHideRoom
+                && earlyRoom != null
+                && this.client.getHabbo().getHabboStats().isOnBuildersClubFreeTrial()
+                && !earlyRoom.hasUserBuildersClubItems(this.client.getHabbo().getHabboInfo().getId());
 
         BuildersClubPlacementSupport.ValidatedPlacement placement = BuildersClubPlacementSupport.validate(this.client, pageId, offerId, FurnitureType.FLOOR);
         if (placement == null) {
@@ -26,6 +36,16 @@ public class BuildersClubPlaceRoomItemMessageEvent extends MessageHandler {
         // validate() reserved an in-flight slot on success; release it on every path below.
         boolean released = false;
         try {
+            if (shouldWarnTrial) {
+                // Release the slot immediately — item is not being placed yet.
+                // The client will resend with confirmHideRoom=true after the user clicks OK.
+                this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
+                released = true;
+                this.client.sendResponse(new BCPlacementWarningMessageComposer(
+                        pageId, offerId, extraData, x, y, rotation));
+                return;
+            }
+
             RoomTile tile = placement.room().getLayout().getTile(x, y);
             if (tile == null) {
                 this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_tile"));
@@ -58,6 +78,15 @@ public class BuildersClubPlaceRoomItemMessageEvent extends MessageHandler {
             this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
             released = true;
             BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+
+            // Hide the room from the navigator on the first confirmed BC item placement by a trial user.
+            if (confirmHideRoom && this.client.getHabbo().getHabboStats().isOnBuildersClubFreeTrial()
+                    && placement.room().getState() != RoomState.INVISIBLE) {
+                placement.room().setState(RoomState.INVISIBLE);
+                placement.room().setNeedsUpdate(true);
+                placement.room().save();
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_ROOM_LOCKED.key));
+            }
         } finally {
             if (!released) {
                 this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemMessageEvent.java
@@ -20,20 +20,31 @@ public class BuildersClubPlaceWallItemMessageEvent extends MessageHandler {
             return;
         }
 
-        HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
-        if (item == null) {
-            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
-            return;
-        }
+        // validate() reserved an in-flight slot on success; release it on every path below.
+        boolean released = false;
+        try {
+            HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
+            if (item == null) {
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
+                return;
+            }
 
-        FurnitureMovementError error = placement.room().placeWallFurniAt(item, wallPosition, this.client.getHabbo());
-        if (!error.equals(FurnitureMovementError.NONE)) {
-            com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
-            this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
-            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
-            return;
-        }
+            FurnitureMovementError error = placement.room().placeWallFurniAt(item, wallPosition, this.client.getHabbo());
+            if (!error.equals(FurnitureMovementError.NONE)) {
+                com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+                this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
+                return;
+            }
 
-        BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+            // Release the reservation first so sendUpdatedState sees the fresh post-commit count.
+            this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
+            released = true;
+            BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+        } finally {
+            if (!released) {
+                this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
+            }
+        }
     }
 }

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemMessageEvent.java
@@ -2,8 +2,10 @@ package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.rooms.RoomState;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.catalog.BCPlacementWarningMessageComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.generic.alerts.NotificationDialogMessageComposer;
 
@@ -14,6 +16,14 @@ public class BuildersClubPlaceWallItemMessageEvent extends MessageHandler {
         int offerId = this.packet.readInt();
         String extraData = this.packet.readString();
         String wallPosition = this.packet.readString();
+        boolean confirmHideRoom = this.packet.readBoolean();
+
+        // Check trial warning condition before validate() reserves a slot.
+        var earlyRoom = this.client.getHabbo().getHabboInfo().getCurrentRoom();
+        boolean shouldWarnTrial = !confirmHideRoom
+                && earlyRoom != null
+                && this.client.getHabbo().getHabboStats().isOnBuildersClubFreeTrial()
+                && !earlyRoom.hasUserBuildersClubItems(this.client.getHabbo().getHabboInfo().getId());
 
         BuildersClubPlacementSupport.ValidatedPlacement placement = BuildersClubPlacementSupport.validate(this.client, pageId, offerId, FurnitureType.WALL);
         if (placement == null) {
@@ -23,6 +33,16 @@ public class BuildersClubPlaceWallItemMessageEvent extends MessageHandler {
         // validate() reserved an in-flight slot on success; release it on every path below.
         boolean released = false;
         try {
+            if (shouldWarnTrial) {
+                // Release the slot immediately — item is not being placed yet.
+                // The client will resend with confirmHideRoom=true after the user clicks OK.
+                this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
+                released = true;
+                this.client.sendResponse(new BCPlacementWarningMessageComposer(
+                        pageId, offerId, extraData, wallPosition));
+                return;
+            }
+
             HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
             if (item == null) {
                 this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
@@ -41,6 +61,15 @@ public class BuildersClubPlaceWallItemMessageEvent extends MessageHandler {
             this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();
             released = true;
             BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+
+            // Hide the room from the navigator on the first confirmed BC item placement by a trial user.
+            if (confirmHideRoom && this.client.getHabbo().getHabboStats().isOnBuildersClubFreeTrial()
+                    && placement.room().getState() != RoomState.INVISIBLE) {
+                placement.room().setState(RoomState.INVISIBLE);
+                placement.room().setNeedsUpdate(true);
+                placement.room().save();
+                this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_ROOM_LOCKED.key));
+            }
         } finally {
             if (!released) {
                 this.client.getHabbo().getHabboStats().releaseBuildersClubSlot();

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemMessageEvent.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
+import com.eu.habbo.messages.outgoing.generic.alerts.NotificationDialogMessageComposer;
+
+public class BuildersClubPlaceWallItemMessageEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        int pageId = this.packet.readInt();
+        int offerId = this.packet.readInt();
+        String extraData = this.packet.readString();
+        String wallPosition = this.packet.readString();
+
+        BuildersClubPlacementSupport.ValidatedPlacement placement = BuildersClubPlacementSupport.validate(this.client, pageId, offerId, FurnitureType.WALL);
+        if (placement == null) {
+            return;
+        }
+
+        HabboItem item = BuildersClubPlacementSupport.createBuildersClubItem(this.client.getHabbo(), placement.baseItem(), extraData);
+        if (item == null) {
+            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.create_failed"));
+            return;
+        }
+
+        FurnitureMovementError error = placement.room().placeWallFurniAt(item, wallPosition, this.client.getHabbo());
+        if (!error.equals(FurnitureMovementError.NONE)) {
+            com.eu.habbo.Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+            this.client.getHabbo().getHabboStats().invalidateBuildersClubFurniCount();
+            this.client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
+            return;
+        }
+
+        BuildersClubPlacementSupport.sendUpdatedState(this.client.getHabbo());
+    }
+}

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlacementSupport.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlacementSupport.java
@@ -1,0 +1,103 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogItem;
+import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageMode;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomRightLevels;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
+import com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
+import com.eu.habbo.messages.outgoing.generic.alerts.NotificationDialogMessageComposer;
+import com.eu.habbo.messages.outgoing.unknown.BuildersClubSubscriptionStatusMessageComposer;
+
+final class BuildersClubPlacementSupport {
+    private BuildersClubPlacementSupport() {
+    }
+
+    static ValidatedPlacement validate(GameClient client, int pageId, int offerId, FurnitureType expectedType) {
+        Habbo habbo = client.getHabbo();
+
+        if (habbo == null || !habbo.getRoomUnit().isInRoom()) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.not_in_room"));
+            return null;
+        }
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) {
+            return null;
+        }
+
+        if (!SubscriptionBuildersClub.isEnabled() || !habbo.getHabboStats().hasEffectiveBuildersClub()) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.membership_required"));
+            return null;
+        }
+
+        boolean isOwner = room.isOwner(habbo);
+        boolean guildPlacementAllowed = room.hasGuild()
+                && SubscriptionBuildersClub.GROUP_ROOM_PLACEMENT_ENABLED
+                && room.getGuildRightLevel(habbo).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS);
+
+        if (!isOwner && !guildPlacementAllowed) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.room_owner_required"));
+            return null;
+        }
+
+        if (habbo.getHabboStats().getBuildersClubSecondsRemaining() <= 0
+                && SubscriptionBuildersClub.hasVisitorsBlockingPlacement(room, habbo)) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_OWNER.key));
+            return null;
+        }
+
+        if (habbo.getHabboStats().getBuildersClubFurniCount() >= habbo.getHabboStats().getBuildersClubFurniLimit()) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.limit_reached"));
+            return null;
+        }
+
+        CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(pageId, CatalogPageMode.BUILDERS_CLUB);
+        if (page == null || !page.isEnabled() || page.getRank() > habbo.getHabboInfo().getRank().getId()) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_page"));
+            return null;
+        }
+
+        CatalogItem item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, offerId);
+        if (!Emulator.getGameEnvironment().getCatalogManager().isBuildersClubPlaceableItem(page, item)) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_offer"));
+            return null;
+        }
+
+        Item baseItem = item.getBaseItems().iterator().next();
+        if (baseItem.getType() != expectedType) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_type"));
+            return null;
+        }
+
+        return new ValidatedPlacement(room, item, baseItem);
+    }
+
+    static HabboItem createBuildersClubItem(Habbo habbo, Item baseItem, String extraData) {
+        HabboItem item = Emulator.getGameEnvironment().getItemManager().createBuildersClubItem(
+                habbo.getHabboInfo().getId(),
+                baseItem,
+                extraData == null ? "" : extraData
+        );
+
+        habbo.getHabboStats().invalidateBuildersClubFurniCount();
+        return item;
+    }
+
+    static void sendUpdatedState(Habbo habbo) {
+        habbo.getHabboStats().invalidateBuildersClubFurniCount();
+        habbo.getClient().sendResponse(new BuildersClubFurniCountMessageComposer(habbo));
+        habbo.getClient().sendResponse(new BuildersClubSubscriptionStatusMessageComposer(habbo));
+    }
+
+    record ValidatedPlacement(Room room, CatalogItem item, Item baseItem) {
+    }
+}

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlacementSupport.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlacementSupport.java
@@ -55,13 +55,34 @@ final class BuildersClubPlacementSupport {
             return null;
         }
 
-        CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(pageId, CatalogPageMode.BUILDERS_CLUB);
+        CatalogPage page = null;
+        CatalogItem item = null;
+
+        if (pageId > 0) {
+            page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(pageId, CatalogPageMode.BUILDERS_CLUB);
+            if (page != null) {
+                item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, offerId);
+            }
+        }
+
+        // pageId = -1 (from infostand "Place More") — search all BC pages for the offer
+        if (page == null || item == null) {
+            for (CatalogPage candidate : Emulator.getGameEnvironment().getCatalogManager().catalogPages.valueCollection()) {
+                if (candidate == null || candidate.getCatalogType() != CatalogPageMode.BUILDERS_CLUB) continue;
+                CatalogItem found = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(candidate, offerId);
+                if (Emulator.getGameEnvironment().getCatalogManager().isBuildersClubPlaceableItem(candidate, found)) {
+                    page = candidate;
+                    item = found;
+                    break;
+                }
+            }
+        }
+
         if (page == null || !page.isEnabled() || page.getRank() > habbo.getHabboInfo().getRank().getId()) {
             client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_page"));
             return null;
         }
 
-        CatalogItem item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, offerId);
         if (!Emulator.getGameEnvironment().getCatalogManager().isBuildersClubPlaceableItem(page, item)) {
             client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_offer"));
             return null;

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlacementSupport.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlacementSupport.java
@@ -55,11 +55,6 @@ final class BuildersClubPlacementSupport {
             return null;
         }
 
-        if (habbo.getHabboStats().getBuildersClubFurniCount() >= habbo.getHabboStats().getBuildersClubFurniLimit()) {
-            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.limit_reached"));
-            return null;
-        }
-
         CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(pageId, CatalogPageMode.BUILDERS_CLUB);
         if (page == null || !page.isEnabled() || page.getRank() > habbo.getHabboInfo().getRank().getId()) {
             client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_page"));
@@ -75,6 +70,16 @@ final class BuildersClubPlacementSupport {
         Item baseItem = item.getBaseItems().iterator().next();
         if (baseItem.getType() != expectedType) {
             client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.invalid_type"));
+            return null;
+        }
+
+        // Atomically check the furni limit and reserve an in-flight slot. This closes the
+        // TOCTOU gap between the limit check and the DB insert: rapid concurrent placements
+        // would otherwise all pass the check before any of them committed. Must be paired
+        // with exactly one releaseBuildersClubSlot() call per successful reservation via the
+        // try/finally in the placement event handlers.
+        if (!habbo.getHabboStats().tryReserveBuildersClubSlot()) {
+            client.sendResponse(new NotificationDialogMessageComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, "builders_club.limit_reached"));
             return null;
         }
 

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubQueryFurniCountMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubQueryFurniCountMessageEvent.java
@@ -1,10 +1,11 @@
 package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer;
 
 public class BuildersClubQueryFurniCountMessageEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
-        //this.client.sendResponse(new CatalogPagesListMessageComposer(this.client.getHabbo(), "NORMAL"));
+        this.client.sendResponse(new BuildersClubFurniCountMessageComposer(this.client.getHabbo()));
     }
 }

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/GetCatalogIndexEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/GetCatalogIndexEvent.java
@@ -3,19 +3,13 @@ package com.eu.habbo.messages.incoming.catalog;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer;
 import com.eu.habbo.messages.outgoing.catalog.CatalogPagesListMessageComposer;
+import com.eu.habbo.habbohotel.catalog.CatalogPageMode;
 
 public class GetCatalogIndexEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
-
-        String MODE = this.packet.readString();
-        if (MODE.equalsIgnoreCase("normal")) {
-            this.client.sendResponse(new BuildersClubFurniCountMessageComposer(0));
-            this.client.sendResponse(new CatalogPagesListMessageComposer(this.client.getHabbo(), MODE));
-        } else {
-            this.client.sendResponse(new BuildersClubFurniCountMessageComposer(1));
-            this.client.sendResponse(new CatalogPagesListMessageComposer(this.client.getHabbo(), MODE));
-        }
-
+        CatalogPageMode mode = CatalogPageMode.fromClientMode(this.packet.readString());
+        this.client.sendResponse(new BuildersClubFurniCountMessageComposer(this.client.getHabbo()));
+        this.client.sendResponse(new CatalogPagesListMessageComposer(this.client.getHabbo(), mode));
     }
 }

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/GetCatalogPageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/GetCatalogPageEvent.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageMode;
 import com.eu.habbo.habbohotel.modtool.ScripterManager;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.CatalogPageMessageComposer;
@@ -12,9 +13,9 @@ public class GetCatalogPageEvent extends MessageHandler {
     public void handle() throws Exception {
         int catalogPageId = this.packet.readInt();
         int offerId = this.packet.readInt();
-        String mode = this.packet.readString();
+        CatalogPageMode mode = CatalogPageMode.fromClientMode(this.packet.readString());
 
-        CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().catalogPages.get(catalogPageId);
+        CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(catalogPageId, mode);
 
         if (catalogPageId > 0 && page != null) {
             if (page.getRank() <= this.client.getHabbo().getHabboInfo().getRank().getId() && page.isEnabled()) {

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/PurchaseFromCatalogAsGiftEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/PurchaseFromCatalogAsGiftEvent.java
@@ -139,7 +139,7 @@ public class PurchaseFromCatalogAsGiftEvent extends MessageHandler {
                         return;
                     }
 
-                    CatalogItem item = page.getCatalogItem(itemId);
+                    CatalogItem item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, itemId);
 
                     if (item == null) {
                         this.client.sendResponse(new PurchaseErrorMessageComposer(PurchaseErrorMessageComposer.SERVER_ERROR).compose());

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/PurchaseFromCatalogEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/PurchaseFromCatalogEvent.java
@@ -59,13 +59,14 @@ public class PurchaseFromCatalogEvent extends MessageHandler {
             CatalogPage page = null;
 
             if (pageId == -12345678 || pageId == -1) {
-                CatalogItem searchedItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(itemId);
+                CatalogItem searchedItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(itemId);
 
-                if (searchedItem.getOfferId() > 0) {
+                if (searchedItem != null && searchedItem.getOfferId() > 0) {
                     page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(searchedItem.getPageId());
 
                     if(page != null) {
-                        if (page.getCatalogItem(itemId).getOfferId() <= 0) {
+                        CatalogItem pageItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, itemId);
+                        if (pageItem == null || pageItem.getOfferId() <= 0) {
                             page = null;
                         } else if (page.getRank() > this.client.getHabbo().getHabboInfo().getRank().getId()) {
                             page = null;
@@ -200,10 +201,15 @@ public class PurchaseFromCatalogEvent extends MessageHandler {
             CatalogItem item;
 
             if (page instanceof RecentPurchasesLayout)
-                item = this.client.getHabbo().getHabboStats().getRecentPurchases().get(itemId);
+                item = this.client.getHabbo().getHabboStats().getRecentPurchaseByWireId(itemId);
 
             else
-                item = page.getCatalogItem(itemId);
+                item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, itemId);
+
+            if (item == null) {
+                this.client.sendResponse(new PurchaseErrorMessageComposer(PurchaseErrorMessageComposer.SERVER_ERROR).compose());
+                return;
+            }
             // temp patch, can a dev with better knowledge than me look into this asap pls.
             if (page instanceof  BotsLayout) {
                 if (!this.client.getHabbo().hasPermission(Permission.ACC_UNLIMITED_BOTS) && this.client.getHabbo().getInventory().getBotsComponent().getBots().size() >= BotManager.MAXIMUM_BOT_INVENTORY_SIZE) {

--- a/src/main/java/com/eu/habbo/messages/incoming/handshake/SSOTicketMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/handshake/SSOTicketMessageEvent.java
@@ -134,7 +134,8 @@ public class SSOTicketMessageEvent extends MessageHandler {
                 messages.add(new AchievementsScoreMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new IsFirstLoginOfDayComposer(true).compose());
                 messages.add(new MysteryBoxKeysMessageComposer().compose());
-                messages.add(new BuildersClubSubscriptionStatusMessageComposer().compose());
+                messages.add(new BuildersClubSubscriptionStatusMessageComposer(this.client.getHabbo()).compose());
+                messages.add(new com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new CfhTopicsInitMessageComposer().compose());
                 messages.add(new FavouritesMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new GameListMessageComposer().compose());

--- a/src/main/java/com/eu/habbo/messages/incoming/handshake/SSOTicketMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/handshake/SSOTicketMessageEvent.java
@@ -11,6 +11,7 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.habbohotel.users.clothingvalidation.ClothingValidationManager;
 import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionHabboClub;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.messages.NoAuthMessage;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -45,8 +46,6 @@ import java.util.Date;
 public class SSOTicketMessageEvent extends MessageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(SSOTicketMessageEvent.class);
 
-
-
     @Override
     public void handle() throws Exception {
         if (!this.client.getChannel().isOpen()) {
@@ -57,7 +56,8 @@ public class SSOTicketMessageEvent extends MessageHandler {
         if (!Emulator.isReady)
             return;
 
-        if (Emulator.getConfig().getBoolean("encryption.forced", false) && Emulator.getCrypto().isEnabled() && !this.client.isHandshakeFinished()) {
+        if (Emulator.getConfig().getBoolean("encryption.forced", false) && Emulator.getCrypto().isEnabled()
+                && !this.client.isHandshakeFinished()) {
             Emulator.getGameServer().getGameClientManager().disposeClient(this.client);
             LOGGER.warn("Encryption is forced and TLS Handshake isn't finished! Closed connection...");
             return;
@@ -83,7 +83,7 @@ public class SSOTicketMessageEvent extends MessageHandler {
                 try {
                     habbo.setClient(this.client);
                     this.client.setHabbo(habbo);
-                    if(!this.client.getHabbo().connect()) {
+                    if (!this.client.getHabbo().connect()) {
                         Emulator.getGameServer().getGameClientManager().disposeClient(this.client);
                         return;
                     }
@@ -94,7 +94,8 @@ public class SSOTicketMessageEvent extends MessageHandler {
                     }
 
                     if (this.client.getHabbo().getHabboInfo().getRank() == null) {
-                        throw new NullPointerException(habbo.getHabboInfo().getUsername() + " has a NON EXISTING RANK!");
+                        throw new NullPointerException(
+                                habbo.getHabboInfo().getUsername() + " has a NON EXISTING RANK!");
                     }
 
                     Emulator.getThreading().run(habbo);
@@ -105,9 +106,9 @@ public class SSOTicketMessageEvent extends MessageHandler {
                     return;
                 }
 
-                if(ClothingValidationManager.VALIDATE_ON_LOGIN) {
+                if (ClothingValidationManager.VALIDATE_ON_LOGIN) {
                     String validated = ClothingValidationManager.validateLook(this.client.getHabbo());
-                    if(!validated.equals(this.client.getHabbo().getHabboInfo().getLook())) {
+                    if (!validated.equals(this.client.getHabbo().getHabboInfo().getLook())) {
                         this.client.getHabbo().getHabboInfo().setLook(validated);
                     }
                 }
@@ -118,31 +119,41 @@ public class SSOTicketMessageEvent extends MessageHandler {
 
                 int roomIdToEnter = 0;
 
-                if (!this.client.getHabbo().getHabboStats().nux || Emulator.getConfig().getBoolean("retro.style.homeroom") && this.client.getHabbo().getHabboInfo().getHomeRoom() != 0)
+                if (!this.client.getHabbo().getHabboStats().nux
+                        || Emulator.getConfig().getBoolean("retro.style.homeroom")
+                                && this.client.getHabbo().getHabboInfo().getHomeRoom() != 0)
                     roomIdToEnter = this.client.getHabbo().getHabboInfo().getHomeRoom();
-                else if (!this.client.getHabbo().getHabboStats().nux || Emulator.getConfig().getBoolean("retro.style.homeroom") && RoomManager.HOME_ROOM_ID > 0)
+                else if (!this.client.getHabbo().getHabboStats().nux
+                        || Emulator.getConfig().getBoolean("retro.style.homeroom") && RoomManager.HOME_ROOM_ID > 0)
                     roomIdToEnter = RoomManager.HOME_ROOM_ID;
 
-                messages.add(new NavigatorSettingsMessageComposer(this.client.getHabbo().getHabboInfo().getHomeRoom(), roomIdToEnter).compose());
-                messages.add(new AvatarEffectsMessageComposer(habbo, this.client.getHabbo().getInventory().getEffectsComponent().effects.values()).compose());
+                messages.add(new NavigatorSettingsMessageComposer(this.client.getHabbo().getHabboInfo().getHomeRoom(),
+                        roomIdToEnter).compose());
+                messages.add(new AvatarEffectsMessageComposer(habbo,
+                        this.client.getHabbo().getInventory().getEffectsComponent().effects.values()).compose());
                 messages.add(new FigureSetIdsMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new NoobnessLevelMessageComposer(habbo).compose());
                 messages.add(new UserRightsMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new AvailabilityStatusMessageComposer(true, false, true).compose());
                 messages.add(new PingMessageComposer().compose());
-                messages.add(new InfoFeedEnableMessageComposer(Emulator.getConfig().getBoolean("bubblealerts.enabled", true)).compose());
+                messages.add(
+                        new InfoFeedEnableMessageComposer(Emulator.getConfig().getBoolean("bubblealerts.enabled", true))
+                                .compose());
                 messages.add(new AchievementsScoreMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new IsFirstLoginOfDayComposer(true).compose());
                 messages.add(new MysteryBoxKeysMessageComposer().compose());
                 messages.add(new BuildersClubSubscriptionStatusMessageComposer(this.client.getHabbo()).compose());
-                messages.add(new com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer(this.client.getHabbo()).compose());
+                messages.add(new com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountMessageComposer(
+                        this.client.getHabbo()).compose());
                 messages.add(new CfhTopicsInitMessageComposer().compose());
                 messages.add(new FavouritesMessageComposer(this.client.getHabbo()).compose());
                 messages.add(new GameListMessageComposer().compose());
                 messages.add(new Game2AccountGameStatusMessageComposer(3, 100).compose());
                 messages.add(new Game2AccountGameStatusMessageComposer(0, 100).compose());
 
-                messages.add(new ScrSendUserInfoMessageComposer(this.client.getHabbo(), SubscriptionHabboClub.HABBO_CLUB, ScrSendUserInfoMessageComposer.RESPONSE_TYPE_LOGIN).compose());
+                messages.add(
+                        new ScrSendUserInfoMessageComposer(this.client.getHabbo(), SubscriptionHabboClub.HABBO_CLUB,
+                                ScrSendUserInfoMessageComposer.RESPONSE_TYPE_LOGIN).compose());
 
                 if (this.client.getHabbo().hasPermission(Permission.ACC_SUPPORTTOOL)) {
                     messages.add(new ModeratorInitMessageComposer(this.client.getHabbo()).compose());
@@ -150,29 +161,34 @@ public class SSOTicketMessageEvent extends MessageHandler {
 
                 this.client.sendResponses(messages);
 
-                //Hardcoded
-                //this.client.sendResponse(new ForumsTestComposer());
+                // Hardcoded
+                // this.client.sendResponse(new ForumsTestComposer());
                 this.client.sendResponse(new BadgePointLimitsMessageComposer());
 
                 ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
                 if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                    THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
-                    ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(habbo.getHabboInfo().getId());
+                    THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator
+                            .getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
+                    ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap
+                            .get(habbo.getHabboInfo().getId());
 
                     if (modToolSanctionItems != null && modToolSanctionItems.size() > 0) {
                         ModToolSanctionItem item = modToolSanctionItems.get(modToolSanctionItems.size() - 1);
 
-                        if (item.sanctionLevel > 0 && item.probationTimestamp != 0 && item.probationTimestamp > Emulator.getIntUnixTimestamp()) {
+                        if (item.sanctionLevel > 0 && item.probationTimestamp != 0
+                                && item.probationTimestamp > Emulator.getIntUnixTimestamp()) {
                             this.client.sendResponse(new SanctionStatusMessageComposer(this.client.getHabbo()));
-                        } else if (item.sanctionLevel > 0 && item.probationTimestamp != 0 && item.probationTimestamp <= Emulator.getIntUnixTimestamp()) {
+                        } else if (item.sanctionLevel > 0 && item.probationTimestamp != 0
+                                && item.probationTimestamp <= Emulator.getIntUnixTimestamp()) {
                             modToolSanctions.updateSanction(item.id, 0);
                         }
 
                         if (item.tradeLockedUntil > 0 && item.tradeLockedUntil <= Emulator.getIntUnixTimestamp()) {
                             modToolSanctions.updateTradeLockedUntil(item.id, 0);
                             habbo.getHabboStats().setAllowTrade(true);
-                        } else if (item.tradeLockedUntil > 0 && item.tradeLockedUntil > Emulator.getIntUnixTimestamp()) {
+                        } else if (item.tradeLockedUntil > 0
+                                && item.tradeLockedUntil > Emulator.getIntUnixTimestamp()) {
                             habbo.getHabboStats().setAllowTrade(false);
                         }
 
@@ -187,10 +203,11 @@ public class SSOTicketMessageEvent extends MessageHandler {
                     }
                 }
 
-                UserLoginEvent userLoginEvent = new UserLoginEvent(habbo, this.client.getHabbo().getHabboInfo().getIpLogin());
+                UserLoginEvent userLoginEvent = new UserLoginEvent(habbo,
+                        this.client.getHabbo().getHabboInfo().getIpLogin());
                 Emulator.getPluginManager().fireEvent(userLoginEvent);
 
-                if(userLoginEvent.isCancelled()) {
+                if (userLoginEvent.isCancelled()) {
                     Emulator.getGameServer().getGameClientManager().disposeClient(this.client);
                     return;
                 }
@@ -199,20 +216,29 @@ public class SSOTicketMessageEvent extends MessageHandler {
                     final Habbo finalHabbo = habbo;
                     Emulator.getThreading().run(() -> {
                         if (Emulator.getConfig().getBoolean("hotel.welcome.alert.oldstyle")) {
-                            SSOTicketMessageEvent.this.client.sendResponse(new MOTDNotificationMessageComposer(HabboManager.WELCOME_MESSAGE.replace("%username%", finalHabbo.getHabboInfo().getUsername()).replace("%user%", finalHabbo.getHabboInfo().getUsername()).split("<br/>")));
+                            SSOTicketMessageEvent.this.client
+                                    .sendResponse(new MOTDNotificationMessageComposer(HabboManager.WELCOME_MESSAGE
+                                            .replace("%username%", finalHabbo.getHabboInfo().getUsername())
+                                            .replace("%user%", finalHabbo.getHabboInfo().getUsername())
+                                            .split("<br/>")));
                         } else {
-                            SSOTicketMessageEvent.this.client.sendResponse(new HabboBroadcastMessageComposer(HabboManager.WELCOME_MESSAGE.replace("%username%", finalHabbo.getHabboInfo().getUsername()).replace("%user%", finalHabbo.getHabboInfo().getUsername())));
+                            SSOTicketMessageEvent.this.client
+                                    .sendResponse(new HabboBroadcastMessageComposer(HabboManager.WELCOME_MESSAGE
+                                            .replace("%username%", finalHabbo.getHabboInfo().getUsername())
+                                            .replace("%user%", finalHabbo.getHabboInfo().getUsername())));
                         }
                     }, Emulator.getConfig().getInt("hotel.welcome.alert.delay", 5000));
                 }
 
-                if(SubscriptionHabboClub.HC_PAYDAY_ENABLED) {
+                if (SubscriptionHabboClub.HC_PAYDAY_ENABLED) {
                     SubscriptionHabboClub.processUnclaimed(habbo);
                 }
 
                 SubscriptionHabboClub.processClubBadge(habbo);
 
                 Messenger.checkFriendSizeProgress(habbo);
+
+                SubscriptionBuildersClub.checkExpiryWarning(habbo);
 
                 if (!habbo.getHabboStats().hasGottenDefaultSavedSearches) {
                     habbo.getHabboStats().hasGottenDefaultSavedSearches = true;
@@ -222,7 +248,8 @@ public class SSOTicketMessageEvent extends MessageHandler {
                     habbo.getHabboInfo().addSavedSearch(new NavigatorSavedSearch("my", ""));
                     habbo.getHabboInfo().addSavedSearch(new NavigatorSavedSearch("favorites", ""));
 
-                    this.client.sendResponse(new NavigatorSavedSearchesMessageComposer(this.client.getHabbo().getHabboInfo().getSavedSearches()));
+                    this.client.sendResponse(new NavigatorSavedSearchesMessageComposer(
+                            this.client.getHabbo().getHabboInfo().getSavedSearches()));
                 }
             } else {
                 Emulator.getGameServer().getGameClientManager().disposeClient(this.client);

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PickupObjectMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PickupObjectMessageEvent.java
@@ -4,6 +4,7 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionPostIt;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.messages.incoming.MessageHandler;
 
 public class PickupObjectMessageEvent extends MessageHandler {
@@ -24,6 +25,14 @@ public class PickupObjectMessageEvent extends MessageHandler {
 
         if (item instanceof InteractionPostIt)
             return;
+
+        if (SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+            if (item.getUserId() == this.client.getHabbo().getHabboInfo().getId() || room.hasRights(this.client.getHabbo())) {
+                room.pickUpBuildersClubItem(item, this.client.getHabbo());
+                SubscriptionBuildersClub.pushCatalogState(this.client.getHabbo());
+            }
+            return;
+        }
 
         if (item.getUserId() == this.client.getHabbo().getHabboInfo().getId()) {
             room.pickUpItem(item, this.client.getHabbo());

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PickupObjectMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PickupObjectMessageEvent.java
@@ -40,11 +40,12 @@ public class PickupObjectMessageEvent extends MessageHandler {
             if (room.hasRights(this.client.getHabbo())) {
                 if (this.client.getHabbo().hasPermission(Permission.ACC_ANYROOMOWNER)) {
                     item.setUserId(this.client.getHabbo().getHabboInfo().getId());
+                    room.pickUpItem(item, this.client.getHabbo());
                 } else if (this.client.getHabbo().getHabboInfo().getId() != room.getOwnerId() && item.getUserId() == room.getOwnerId()) {
                     return;
+                } else {
+                    room.ejectUserItem(item);
                 }
-
-                room.ejectUserItem(item);
             }
         }
     }

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PickupObjectMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PickupObjectMessageEvent.java
@@ -26,7 +26,7 @@ public class PickupObjectMessageEvent extends MessageHandler {
         if (item instanceof InteractionPostIt)
             return;
 
-        if (SubscriptionBuildersClub.isBuildersClubItemId(item.getId())) {
+        if (item.isBuildersClub()) {
             if (item.getUserId() == this.client.getHabbo().getHabboInfo().getId() || room.hasRights(this.client.getHabbo())) {
                 room.pickUpBuildersClubItem(item, this.client.getHabbo());
                 SubscriptionBuildersClub.pushCatalogState(this.client.getHabbo());

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/promotions/PurchaseRoomAdMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/promotions/PurchaseRoomAdMessageEvent.java
@@ -33,7 +33,7 @@ public class PurchaseRoomAdMessageEvent extends MessageHandler {
         if (page == null || !page.getLayout().equals("roomads"))
             return;
 
-        CatalogItem item = page.getCatalogItem(itemId);
+        CatalogItem item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItemByWireId(page, itemId);
         if (item != null) {
             if (this.client.getHabbo().getHabboInfo().canBuy(item)) {
                 Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(roomId);

--- a/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -114,6 +114,7 @@ public class Outgoing {
     public final static int WiredRewardResultMessageComposer = 178; // PRODUCTION-201611291003-338511768
     public final static int CatalogPageMessageComposer = 804; // PRODUCTION-201611291003-338511768
     public final static int BuildersClubFurniCountMessageComposer = 3828; // PRODUCTION-201611291003-338511768
+    public final static int BCPlacementWarningMessageComposer = 2898; // PRODUCTION-201611291003-338511768
     public final static int ChangeNameUpdateComposer = 118; // PRODUCTION-201611291003-338511768
     public final static int ObjectAddMessageComposer = 1534; // PRODUCTION-201611291003-338511768
     public final static int InfoFeedEnableMessageComposer = 3284; // PRODUCTION-201611291003-338511768

--- a/src/main/java/com/eu/habbo/messages/outgoing/catalog/BCPlacementWarningMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/catalog/BCPlacementWarningMessageComposer.java
@@ -1,0 +1,67 @@
+package com.eu.habbo.messages.outgoing.catalog;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public class BCPlacementWarningMessageComposer extends MessageComposer {
+
+    public static final int TYPE_FLOOR = 0;
+    public static final int TYPE_WALL  = 1;
+
+    private final int typeCode;
+    private final int pageId;
+    private final int offerId;
+    private final String extraParam;
+
+    // Floor fields
+    private final int x;
+    private final int y;
+    private final int rotation;
+
+    // Wall field
+    private final String wallLocation;
+
+    /** Floor item warning. */
+    public BCPlacementWarningMessageComposer(int pageId, int offerId, String extraParam,
+                                             int x, int y, int rotation) {
+        this.typeCode    = TYPE_FLOOR;
+        this.pageId      = pageId;
+        this.offerId     = offerId;
+        this.extraParam  = extraParam;
+        this.x           = x;
+        this.y           = y;
+        this.rotation    = rotation;
+        this.wallLocation = null;
+    }
+
+    /** Wall item warning. */
+    public BCPlacementWarningMessageComposer(int pageId, int offerId, String extraParam,
+                                             String wallLocation) {
+        this.typeCode     = TYPE_WALL;
+        this.pageId       = pageId;
+        this.offerId      = offerId;
+        this.extraParam   = extraParam;
+        this.wallLocation = wallLocation;
+        this.x            = 0;
+        this.y            = 0;
+        this.rotation     = 0;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.BCPlacementWarningMessageComposer);
+        this.response.appendInt(this.typeCode);
+        this.response.appendInt(this.pageId);
+        this.response.appendInt(this.offerId);
+        this.response.appendString(this.extraParam);
+        if (this.typeCode == TYPE_FLOOR) {
+            this.response.appendInt(this.x);
+            this.response.appendInt(this.y);
+            this.response.appendInt(this.rotation);
+        } else {
+            this.response.appendString(this.wallLocation);
+        }
+        return this.response;
+    }
+}

--- a/src/main/java/com/eu/habbo/messages/outgoing/catalog/BuildersClubFurniCountMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/catalog/BuildersClubFurniCountMessageComposer.java
@@ -1,24 +1,29 @@
 package com.eu.habbo.messages.outgoing.catalog;
 
+import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 public class BuildersClubFurniCountMessageComposer extends MessageComposer {
-    private final int mode;
+    private final int furniCount;
 
-    public BuildersClubFurniCountMessageComposer(int mode) {
-        this.mode = mode;
+    public BuildersClubFurniCountMessageComposer(Habbo habbo) {
+        this(habbo.getHabboStats().getBuildersClubFurniCount());
+    }
+
+    public BuildersClubFurniCountMessageComposer(int furniCount) {
+        this.furniCount = furniCount;
     }
 
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.BuildersClubFurniCountMessageComposer);
-        this.response.appendInt(this.mode);
+        this.response.appendInt(this.furniCount);
         return this.response;
     }
 
-    public int getMode() {
-        return mode;
+    public int getFurniCount() {
+        return furniCount;
     }
 }

--- a/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageMessageComposer.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.catalog.CatalogFeaturedPage;
 import com.eu.habbo.habbohotel.catalog.CatalogItem;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageMode;
 import com.eu.habbo.habbohotel.catalog.layouts.FrontPageFeaturedLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.FrontpageLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.RecentPurchasesLayout;
@@ -21,9 +22,13 @@ public class CatalogPageMessageComposer extends MessageComposer {
     private final CatalogPage page;
     private final Habbo habbo;
     private final int offerId;
-    private final String mode;
+    private final CatalogPageMode mode;
 
     public CatalogPageMessageComposer(CatalogPage page, Habbo habbo, int offerId, String mode) {
+        this(page, habbo, offerId, CatalogPageMode.fromClientMode(mode));
+    }
+
+    public CatalogPageMessageComposer(CatalogPage page, Habbo habbo, int offerId, CatalogPageMode mode) {
         this.page = page;
         this.habbo = habbo;
         this.offerId = offerId;
@@ -34,7 +39,7 @@ public class CatalogPageMessageComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.CatalogPageMessageComposer);
         this.response.appendInt(this.page.getId());
-        this.response.appendString(this.mode);
+        this.response.appendString(this.mode.getClientMode());
         this.page.serialize(this.response);
 
         if (this.page instanceof RecentPurchasesLayout) {
@@ -44,9 +49,8 @@ public class CatalogPageMessageComposer extends MessageComposer {
                 item.getValue().serialize(this.response);
             }
         } else {
-            this.response.appendInt(this.page.getCatalogItems().size());
-            List<CatalogItem> items = new ArrayList<>(this.page.getCatalogItems().valueCollection());
-            Collections.sort(items);
+            List<CatalogItem> items = Emulator.getGameEnvironment().getCatalogManager().getVisibleCatalogItems(this.page, this.habbo, this.mode);
+            this.response.appendInt(items.size());
             for (CatalogItem item : items) {
                 item.serialize(this.response);
             }
@@ -82,6 +86,6 @@ public class CatalogPageMessageComposer extends MessageComposer {
     }
 
     public String getMode() {
-        return mode;
+        return mode.getClientMode();
     }
 }

--- a/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListMessageComposer.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.outgoing.catalog;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageMode;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
@@ -16,10 +17,14 @@ public class CatalogPagesListMessageComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPagesListMessageComposer.class);
 
     private final Habbo habbo;
-    private final String mode;
+    private final CatalogPageMode mode;
     private final boolean hasPermission;
 
     public CatalogPagesListMessageComposer(Habbo habbo, String mode) {
+        this(habbo, CatalogPageMode.fromClientMode(mode));
+    }
+
+    public CatalogPagesListMessageComposer(Habbo habbo, CatalogPageMode mode) {
         this.habbo = habbo;
         this.mode = mode;
         this.hasPermission = this.habbo.hasPermission(Permission.ACC_CATALOG_IDS);
@@ -28,7 +33,7 @@ public class CatalogPagesListMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         try {
-            List<CatalogPage> pages = Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(-1, this.habbo);
+            List<CatalogPage> pages = Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(-1, this.habbo, this.mode);
 
             this.response.init(Outgoing.CatalogPagesListMessageComposer);
 
@@ -45,7 +50,7 @@ public class CatalogPagesListMessageComposer extends MessageComposer {
             }
 
             this.response.appendBoolean(false);
-            this.response.appendString(this.mode);
+            this.response.appendString(this.mode.getClientMode());
 
             return this.response;
         } catch (Exception e) {
@@ -56,7 +61,7 @@ public class CatalogPagesListMessageComposer extends MessageComposer {
     }
 
     private void append(CatalogPage category) {
-        List<CatalogPage> pagesList = Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(category.getId(), this.habbo);
+        List<CatalogPage> pagesList = Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(category.getId(), this.habbo, this.mode);
 
         this.response.appendBoolean(category.isVisible());
         this.response.appendInt(category.getIconImage());
@@ -82,7 +87,7 @@ public class CatalogPagesListMessageComposer extends MessageComposer {
     }
 
     public String getMode() {
-        return mode;
+        return mode.getClientMode();
     }
 
     public boolean isHasPermission() {

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/CustomStackingHeightUpdateMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/CustomStackingHeightUpdateMessageComposer.java
@@ -18,7 +18,7 @@ public class CustomStackingHeightUpdateMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.CustomStackingHeightUpdateMessageComposer);
-        this.response.appendInt(this.item.getId());
+        this.response.appendInt(this.item.getRoomVisibleId());
         this.response.appendInt(this.height);
         return this.response;
     }

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/FloorItemOnRollerComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/FloorItemOnRollerComposer.java
@@ -51,10 +51,10 @@ public class FloorItemOnRollerComposer extends MessageComposer {
         this.response.appendInt(this.newLocation.x);
         this.response.appendInt(this.newLocation.y);
         this.response.appendInt(1);
-        this.response.appendInt(this.item.getId());
+        this.response.appendInt(this.item.getRoomVisibleId());
         this.response.appendString(Double.toString(this.oldLocation != null ? this.oldZ : this.item.getZ()));
         this.response.appendString(Double.toString(this.oldLocation != null ? this.newZ : (this.item.getZ() + this.heightOffset)));
-        this.response.appendInt(this.roller != null ? this.roller.getId() : -1);
+        this.response.appendInt(this.roller != null ? this.roller.getRoomVisibleId() : -1);
 
         if(this.oldLocation == null) {
             this.item.onMove(this.room, this.room.getLayout().getTile(this.item.getX(), this.item.getY()), this.newLocation);

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ItemRemoveMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ItemRemoveMessageComposer.java
@@ -15,7 +15,7 @@ public class ItemRemoveMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.ItemRemoveMessageComposer);
-        this.response.appendString(this.item.getId() + "");
+        this.response.appendString(this.item.getRoomVisibleId() + "");
         this.response.appendInt(this.item.getUserId());
         return this.response;
     }

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ObjectDataUpdateMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ObjectDataUpdateMessageComposer.java
@@ -15,7 +15,7 @@ public class ObjectDataUpdateMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.ObjectDataUpdateMessageComposer);
-        this.response.appendString(this.item.getId() + "");
+        this.response.appendString(this.item.getRoomVisibleId() + "");
         this.item.serializeExtradata(this.response);
         return this.response;
     }

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ObjectRemoveMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ObjectRemoveMessageComposer.java
@@ -23,7 +23,7 @@ public class ObjectRemoveMessageComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.ObjectRemoveMessageComposer);
 
-        this.response.appendString(this.item.getId() + "");
+        this.response.appendString(this.item.getRoomVisibleId() + "");
         this.response.appendBoolean(false);
         this.response.appendInt(this.noUser ? 0 : this.item.getUserId());
         this.response.appendInt(0);

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ObjectsDataUpdateMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ObjectsDataUpdateMessageComposer.java
@@ -20,7 +20,7 @@ public class ObjectsDataUpdateMessageComposer extends MessageComposer {
         this.response.appendInt(this.items.size());
 
         for (HabboItem item : this.items) {
-            this.response.appendInt(item.getId());
+            this.response.appendInt(item.getRoomVisibleId());
             item.serializeExtradata(this.response);
         }
 

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/OneWayDoorStatusMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/OneWayDoorStatusMessageComposer.java
@@ -15,7 +15,7 @@ public class OneWayDoorStatusMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.OneWayDoorStatusMessageComposer);
-        this.response.appendInt(this.item.getId());
+        this.response.appendInt(this.item.getRoomVisibleId());
         try {
             int state = Integer.parseInt(this.item.getExtradata());
             this.response.appendInt(state);

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/PresentOpenedMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/PresentOpenedMessageComposer.java
@@ -22,7 +22,7 @@ public class PresentOpenedMessageComposer extends MessageComposer {
         this.response.appendString(this.item.getBaseItem().getType().code.toLowerCase());
         this.response.appendInt(this.item.getBaseItem().getSpriteId());
         this.response.appendString(this.item.getBaseItem().getName());
-        this.response.appendInt(this.item.getId());
+        this.response.appendInt(this.item.getRoomVisibleId());
         this.response.appendString(this.item.getBaseItem().getType().code.toLowerCase());
         this.response.appendBoolean(this.unknown);
         this.response.appendString(this.text);

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RequestSpamWallPostItMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RequestSpamWallPostItMessageComposer.java
@@ -15,7 +15,7 @@ public class RequestSpamWallPostItMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RequestSpamWallPostItMessageComposer);
-        this.response.appendInt(this.item == null ? -1234 : this.item.getId());
+        this.response.appendInt(this.item == null ? -1234 : this.item.getRoomVisibleId());
         this.response.appendString("");
         return this.response;
     }

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/FriendFurniCancelLockMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/FriendFurniCancelLockMessageComposer.java
@@ -15,7 +15,7 @@ public class FriendFurniCancelLockMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.FriendFurniCancelLockMessageComposer);
-        this.response.appendInt(this.loveLock.getId());
+        this.response.appendInt(this.loveLock.getRoomVisibleId());
         return this.response;
     }
 

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/FriendFurniOtherLockConfirmedMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/FriendFurniOtherLockConfirmedMessageComposer.java
@@ -15,7 +15,7 @@ public class FriendFurniOtherLockConfirmedMessageComposer extends MessageCompose
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.FriendFurniOtherLockConfirmedMessageComposer);
-        this.response.appendInt(this.loveLock.getId());
+        this.response.appendInt(this.loveLock.getRoomVisibleId());
         return this.response;
     }
 

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/FriendFurniStartConfirmationMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/FriendFurniStartConfirmationMessageComposer.java
@@ -15,7 +15,7 @@ public class FriendFurniStartConfirmationMessageComposer extends MessageComposer
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.FriendFurniStartConfirmationMessageComposer);
-        this.response.appendInt(this.loveLock.getId());
+        this.response.appendInt(this.loveLock.getRoomVisibleId());
         this.response.appendBoolean(true);
         return this.response;
     }

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/FurnitureAliasesMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/FurnitureAliasesMessageComposer.java
@@ -15,7 +15,7 @@ public class FurnitureAliasesMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.LeprechaunStarterBundleComposer);
-        this.response.appendInt(this.item.getId());
+        this.response.appendInt(this.item.getRoomVisibleId());
         return this.response;
     }
 

--- a/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/SlideObjectBundleMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/SlideObjectBundleMessageComposer.java
@@ -95,7 +95,7 @@ public class SlideObjectBundleMessageComposer extends MessageComposer {
         this.response.appendInt(this.newLocation.x);
         this.response.appendInt(this.newLocation.y);
         this.response.appendInt(0);
-        this.response.appendInt(this.roller == null ? 0 : this.roller.getId());
+        this.response.appendInt(this.roller == null ? 0 : this.roller.getRoomVisibleId());
         this.response.appendInt(2);
         this.response.appendInt(this.roomUnit.getId());
         this.response.appendString(this.oldZ + "");

--- a/src/main/java/com/eu/habbo/messages/outgoing/unknown/BuildersClubSubscriptionStatusMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/unknown/BuildersClubSubscriptionStatusMessageComposer.java
@@ -1,18 +1,24 @@
 package com.eu.habbo.messages.outgoing.unknown;
 
+import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 public class BuildersClubSubscriptionStatusMessageComposer extends MessageComposer {
+    private final Habbo habbo;
+
+    public BuildersClubSubscriptionStatusMessageComposer(Habbo habbo) {
+        this.habbo = habbo;
+    }
+
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.BuildersClubSubscriptionStatusMessageComposer);
-        this.response.appendInt(Integer.MAX_VALUE);
-        this.response.appendInt(0);
-        this.response.appendInt(100);
-        this.response.appendInt(Integer.MAX_VALUE);
-        this.response.appendInt(0);
+        this.response.appendInt(this.habbo.getHabboStats().getBuildersClubSecondsRemaining());
+        this.response.appendInt(this.habbo.getHabboStats().getBuildersClubFurniLimit());
+        this.response.appendInt(this.habbo.getHabboStats().getBuildersClubMaxFurniLimit());
+        this.response.appendInt(this.habbo.getHabboStats().getBuildersClubSecondsRemainingWithGrace());
         return this.response;
     }
 }

--- a/src/main/java/com/eu/habbo/messages/outgoing/users/PerkAllowancesMessageComposer.java
+++ b/src/main/java/com/eu/habbo/messages/outgoing/users/PerkAllowancesMessageComposer.java
@@ -53,7 +53,7 @@ public class PerkAllowancesMessageComposer extends MessageComposer {
 
         this.response.appendString("BUILDER_AT_WORK");
         this.response.appendString("");
-        this.response.appendBoolean(true);
+        this.response.appendBoolean(this.habbo.getHabboStats().hasEffectiveBuildersClub());
 
         this.response.appendString("CALL_ON_HELPERS");
         this.response.appendString("");

--- a/src/main/java/com/eu/habbo/messages/rcon/UpdateCatalog.java
+++ b/src/main/java/com/eu/habbo/messages/rcon/UpdateCatalog.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.messages.rcon;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.messages.outgoing.catalog.*;
 import com.eu.habbo.messages.outgoing.catalog.marketplace.MarketplaceConfigurationMessageComposer;
 import com.google.gson.Gson;
@@ -15,11 +18,16 @@ public class UpdateCatalog extends RCONMessage<UpdateCatalog.JSONUpdateCatalog> 
     public void handle(Gson gson, JSONUpdateCatalog json) {
         Emulator.getGameEnvironment().getCatalogManager().initialize();
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new CatalogPublishedMessageComposer());
-        Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new BuildersClubFurniCountMessageComposer(0));
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new BundleDiscountRulesetMessageComposer());
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new MarketplaceConfigurationMessageComposer());
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new GiftWrappingConfigurationMessageComposer());
         Emulator.getGameServer().getGameClientManager().sendBroadcastResponse(new RecyclerPrizesMessageComposer());
+        for (GameClient client : Emulator.getGameServer().getGameClientManager().getSessions().values()) {
+            Habbo habbo = client.getHabbo();
+            if (habbo != null && habbo.getClient() != null) {
+                SubscriptionBuildersClub.pushCatalogState(habbo);
+            }
+        }
         Emulator.getGameEnvironment().getCraftingManager().reload();
     }
 

--- a/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -80,26 +80,35 @@ public class PluginManager {
         MarketPlace.MARKETPLACE_CURRENCY = Emulator.getConfig().getInt("hotel.marketplace.currency");
         Messenger.SAVE_PRIVATE_CHATS = Emulator.getConfig().getBoolean("save.private.chats", false);
         PacketManager.DEBUG_SHOW_PACKETS = Emulator.getConfig().getBoolean("debug.show.packets");
-        PacketManager.MULTI_THREADED_PACKET_HANDLING = Emulator.getConfig().getBoolean("io.client.multithreaded.handler");
+        PacketManager.MULTI_THREADED_PACKET_HANDLING = Emulator.getConfig()
+                .getBoolean("io.client.multithreaded.handler");
         Room.HABBO_CHAT_DELAY = Emulator.getConfig().getBoolean("room.chat.delay", false);
         Room.MUTEAREA_CAN_WHISPER = Emulator.getConfig().getBoolean("room.chat.mutearea.allow_whisper", false);
         RoomChatMessage.SAVE_ROOM_CHATS = Emulator.getConfig().getBoolean("save.room.chats", false);
         RoomLayout.MAXIMUM_STEP_HEIGHT = Emulator.getConfig().getDouble("pathfinder.step.maximum.height", 1.1);
         RoomLayout.ALLOW_FALLING = Emulator.getConfig().getBoolean("pathfinder.step.allow.falling", true);
-        RoomTrade.TRADING_ENABLED = Emulator.getConfig().getBoolean("hotel.trading.enabled") && !ShutdownEmulator.instantiated;
+        RoomTrade.TRADING_ENABLED = Emulator.getConfig().getBoolean("hotel.trading.enabled")
+                && !ShutdownEmulator.instantiated;
         RoomTrade.TRADING_REQUIRES_PERK = Emulator.getConfig().getBoolean("hotel.trading.requires.perk");
         WordFilter.ENABLED_FRIENDCHAT = Emulator.getConfig().getBoolean("hotel.wordfilter.messenger");
-        BundleDiscountRulesetMessageComposer.MAXIMUM_ALLOWED_ITEMS = Emulator.getConfig().getInt("discount.max.allowed.items", 100);
-        BundleDiscountRulesetMessageComposer.DISCOUNT_BATCH_SIZE = Emulator.getConfig().getInt("discount.batch.size", 6);
-        BundleDiscountRulesetMessageComposer.DISCOUNT_AMOUNT_PER_BATCH = Emulator.getConfig().getInt("discount.batch.free.items", 1);
-        BundleDiscountRulesetMessageComposer.MINIMUM_DISCOUNTS_FOR_BONUS = Emulator.getConfig().getInt("discount.bonus.min.discounts", 1);
-        BundleDiscountRulesetMessageComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = Arrays.stream(Emulator.getConfig().getValue("discount.additional.thresholds", "40;99").split(";")).mapToInt(Integer::parseInt).toArray();
+        BundleDiscountRulesetMessageComposer.MAXIMUM_ALLOWED_ITEMS = Emulator.getConfig()
+                .getInt("discount.max.allowed.items", 100);
+        BundleDiscountRulesetMessageComposer.DISCOUNT_BATCH_SIZE = Emulator.getConfig().getInt("discount.batch.size",
+                6);
+        BundleDiscountRulesetMessageComposer.DISCOUNT_AMOUNT_PER_BATCH = Emulator.getConfig()
+                .getInt("discount.batch.free.items", 1);
+        BundleDiscountRulesetMessageComposer.MINIMUM_DISCOUNTS_FOR_BONUS = Emulator.getConfig()
+                .getInt("discount.bonus.min.discounts", 1);
+        BundleDiscountRulesetMessageComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = Arrays
+                .stream(Emulator.getConfig().getValue("discount.additional.thresholds", "40;99").split(";"))
+                .mapToInt(Integer::parseInt).toArray();
 
         BotManager.MINIMUM_CHAT_SPEED = Emulator.getConfig().getInt("hotel.bot.chat.minimum.interval");
         BotManager.MAXIMUM_CHAT_LENGTH = Emulator.getConfig().getInt("hotel.bot.max.chatlength");
         BotManager.MAXIMUM_NAME_LENGTH = Emulator.getConfig().getInt("hotel.bot.max.namelength");
         BotManager.MAXIMUM_CHAT_SPEED = Emulator.getConfig().getInt("hotel.bot.max.chatdelay");
-        Bot.PLACEMENT_MESSAGES = Emulator.getConfig().getValue("hotel.bot.placement.messages", "Yo!;Hello I'm a real party animal!;Hello!").split(";");
+        Bot.PLACEMENT_MESSAGES = Emulator.getConfig()
+                .getValue("hotel.bot.placement.messages", "Yo!;Hello I'm a real party animal!;Hello!").split(";");
         Bot.BOT_LIMIT_WALKING_DISTANCE = Emulator.getConfig().getBoolean("hotel.bot.limit.walking.distance", true);
         Bot.BOT_WALKING_DISTANCE_RADIUS = Emulator.getConfig().getInt("hotel.bot.limit.walking.distance.radius", 5);
 
@@ -124,7 +133,8 @@ public class PluginManager {
         WiredEngine.RATE_LIMIT_WINDOW_MS = Emulator.getConfig().getInt("wired.abuse.rate.limit.window.ms", 10000);
         WiredEngine.WIRED_BAN_DURATION_MS = Emulator.getConfig().getInt("wired.abuse.ban.duration.ms", 600000);
         NavigatorManager.MAXIMUM_RESULTS_PER_PAGE = Emulator.getConfig().getInt("hotel.navigator.search.maxresults");
-        NavigatorManager.CATEGORY_SORT_USING_ORDER_NUM = Emulator.getConfig().getBoolean("hotel.navigator.sort.ordernum");
+        NavigatorManager.CATEGORY_SORT_USING_ORDER_NUM = Emulator.getConfig()
+                .getBoolean("hotel.navigator.sort.ordernum");
         RoomChatMessage.MAXIMUM_LENGTH = Emulator.getConfig().getInt("hotel.chat.max.length");
         TraxManager.LARGE_JUKEBOX_LIMIT = Emulator.getConfig().getInt("hotel.jukebox.limit.large");
         TraxManager.NORMAL_JUKEBOX_LIMIT = Emulator.getConfig().getInt("hotel.jukebox.limit.normal");
@@ -139,10 +149,14 @@ public class PluginManager {
             }
         }
 
-        HabboManager.WELCOME_MESSAGE = Emulator.getConfig().getValue("hotel.welcome.alert.message").replace("<br>", "<br/>").replace("<br />", "<br/>").replace("\\r", "\r").replace("\\n", "\n").replace("\\t", "\t");
+        HabboManager.WELCOME_MESSAGE = Emulator.getConfig().getValue("hotel.welcome.alert.message")
+                .replace("<br>", "<br/>").replace("<br />", "<br/>").replace("\\r", "\r").replace("\\n", "\n")
+                .replace("\\t", "\t");
         Room.PREFIX_FORMAT = Emulator.getConfig().getValue("room.chat.prefix.format");
-        UpdateFloorPropertiesMessageEvent.MAXIMUM_FLOORPLAN_WIDTH_LENGTH = Emulator.getConfig().getInt("hotel.floorplan.max.widthlength");
-        UpdateFloorPropertiesMessageEvent.MAXIMUM_FLOORPLAN_SIZE = Emulator.getConfig().getInt("hotel.floorplan.max.totalarea");
+        UpdateFloorPropertiesMessageEvent.MAXIMUM_FLOORPLAN_WIDTH_LENGTH = Emulator.getConfig()
+                .getInt("hotel.floorplan.max.widthlength");
+        UpdateFloorPropertiesMessageEvent.MAXIMUM_FLOORPLAN_SIZE = Emulator.getConfig()
+                .getInt("hotel.floorplan.max.totalarea");
 
         GetLimitedOfferAppearingNextEvent.ENABLED = Emulator.getConfig().getBoolean("hotel.view.ltdcountdown.enabled");
         GetLimitedOfferAppearingNextEvent.TIMESTAMP = Emulator.getConfig().getInt("hotel.view.ltdcountdown.timestamp");
@@ -160,68 +174,95 @@ public class PluginManager {
         ApproveNameMessageEvent.PET_NAME_LENGTH_MINIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.min");
         ApproveNameMessageEvent.PET_NAME_LENGTH_MAXIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.max");
 
-
-        CheckUserNameMessageEvent.VALID_CHARACTERS = Emulator.getConfig().getValue("allowed.username.characters", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-=!?@:,.");
+        CheckUserNameMessageEvent.VALID_CHARACTERS = Emulator.getConfig().getValue("allowed.username.characters",
+                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-=!?@:,.");
         PublishPhotoMessageEvent.CAMERA_PUBLISH_POINTS = Emulator.getConfig().getInt("camera.price.points.publish", 5);
-        PublishPhotoMessageEvent.CAMERA_PUBLISH_POINTS_TYPE = Emulator.getConfig().getInt("camera.price.points.publish.type", 0);
+        PublishPhotoMessageEvent.CAMERA_PUBLISH_POINTS_TYPE = Emulator.getConfig()
+                .getInt("camera.price.points.publish.type", 0);
         PurchasePhotoMessageEvent.CAMERA_PURCHASE_CREDITS = Emulator.getConfig().getInt("camera.price.credits", 5);
         PurchasePhotoMessageEvent.CAMERA_PURCHASE_POINTS = Emulator.getConfig().getInt("camera.price.points", 5);
-        PurchasePhotoMessageEvent.CAMERA_PURCHASE_POINTS_TYPE = Emulator.getConfig().getInt("camera.price.points.type", 0);
+        PurchasePhotoMessageEvent.CAMERA_PURCHASE_POINTS_TYPE = Emulator.getConfig().getInt("camera.price.points.type",
+                0);
 
-        PurchaseRoomAdMessageEvent.ROOM_PROMOTION_BADGE = Emulator.getConfig().getValue("room.promotion.badge", "RADZZ");
+        PurchaseRoomAdMessageEvent.ROOM_PROMOTION_BADGE = Emulator.getConfig().getValue("room.promotion.badge",
+                "RADZZ");
         BotManager.MAXIMUM_BOT_INVENTORY_SIZE = Emulator.getConfig().getInt("hotel.bots.max.inventory");
         PetManager.MAXIMUM_PET_INVENTORY_SIZE = Emulator.getConfig().getInt("hotel.pets.max.inventory");
 
-
-        SubscriptionHabboClub.HC_PAYDAY_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.payday.enabled", false);
+        SubscriptionHabboClub.HC_PAYDAY_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.payday.enabled",
+                false);
 
         try {
-            SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = (int) (Emulator.stringToDate(Emulator.getConfig().getValue("subscriptions.hc.payday.next_date")).getTime() / 1000);
+            SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = (int) (Emulator
+                    .stringToDate(Emulator.getConfig().getValue("subscriptions.hc.payday.next_date")).getTime() / 1000);
+        } catch (Exception e) {
+            SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE;
         }
-        catch(Exception e) { SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE; }
 
         SubscriptionHabboClub.HC_PAYDAY_INTERVAL = Emulator.getConfig().getValue("subscriptions.hc.payday.interval");
         SubscriptionHabboClub.HC_PAYDAY_QUERY = Emulator.getConfig().getValue("subscriptions.hc.payday.query");
         SubscriptionHabboClub.HC_PAYDAY_CURRENCY = Emulator.getConfig().getValue("subscriptions.hc.payday.currency");
-        SubscriptionHabboClub.HC_PAYDAY_KICKBACK_PERCENTAGE = Emulator.getConfig().getInt("subscriptions.hc.payday.percentage", 10) / 100.0;
-        SubscriptionHabboClub.HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE = Emulator.getConfig().getBoolean("subscriptions.hc.payday.creditsspent_reset_on_expire", false);
+        SubscriptionHabboClub.HC_PAYDAY_KICKBACK_PERCENTAGE = Emulator.getConfig()
+                .getInt("subscriptions.hc.payday.percentage", 10) / 100.0;
+        SubscriptionHabboClub.HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE = Emulator.getConfig()
+                .getBoolean("subscriptions.hc.payday.creditsspent_reset_on_expire", false);
         SubscriptionHabboClub.ACHIEVEMENT_NAME = Emulator.getConfig().getValue("subscriptions.hc.achievement", "VipHC");
-        SubscriptionHabboClub.DISCOUNT_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.discount.enabled", false);
-        SubscriptionHabboClub.DISCOUNT_DAYS_BEFORE_END = Emulator.getConfig().getInt("subscriptions.hc.discount.days_before_end", 7);
+        SubscriptionHabboClub.DISCOUNT_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.discount.enabled",
+                false);
+        SubscriptionHabboClub.DISCOUNT_DAYS_BEFORE_END = Emulator.getConfig()
+                .getInt("subscriptions.hc.discount.days_before_end", 7);
 
         SubscriptionBuildersClub.ENABLED = Emulator.getConfig().getBoolean("builders.club.enabled", false);
         SubscriptionBuildersClub.FURNI_LIMIT = Emulator.getConfig().getInt("builders.club.furni.limit", 75);
         SubscriptionBuildersClub.MAX_FURNI_LIMIT = Emulator.getConfig().getInt("builders.club.max.furni.limit", 250);
-        SubscriptionBuildersClub.BOX_FURNI_LIMIT_INCREMENT = Emulator.getConfig().getInt("builders.club.box.furni.limit.increment", 750);
+        SubscriptionBuildersClub.BOX_FURNI_LIMIT_INCREMENT = Emulator.getConfig()
+                .getInt("builders.club.box.furni.limit.increment", 750);
         SubscriptionBuildersClub.GRACE_SECONDS = Emulator.getConfig().getInt("builders.club.grace.seconds", 0);
-        SubscriptionBuildersClub.GROUP_ROOM_PLACEMENT_ENABLED = Emulator.getConfig().getBoolean("builders.club.furniture.placement.group.room.enabled", false);
+        SubscriptionBuildersClub.GROUP_ROOM_PLACEMENT_ENABLED = Emulator.getConfig()
+                .getBoolean("builders.club.furniture.placement.group.room.enabled", false);
         SubscriptionBuildersClub.EXPIRY_ACTION = Emulator.getConfig().getValue("builders.club.expiry.action", "none");
-        SubscriptionBuildersClub.ACHIEVEMENT_NAME = Emulator.getConfig().getValue("builders.club.achievement", "BuildersClub");
-        SubscriptionBuildersClub.BUY_MEMBERSHIP_PAGE = Emulator.getConfig().getValue("builders.club.buy_membership_page", "");
+        SubscriptionBuildersClub.ACHIEVEMENT_NAME = Emulator.getConfig().getValue("builders.club.achievement",
+                "BuildersClub");
+        SubscriptionBuildersClub.BUY_MEMBERSHIP_PAGE = Emulator.getConfig()
+                .getValue("builders.club.buy_membership_page", "");
         SubscriptionBuildersClub.TRY_PAGE = Emulator.getConfig().getValue("builders.club.try_page", "");
         CatalogManager.BUILDERS_CLUB_FURNIDATA_URL = Emulator.getConfig().getValue("builders.club.furnidata.url", "");
+        SubscriptionBuildersClub.FREE_TRIAL_ENABLED = Emulator.getConfig()
+                .getBoolean("builders.club.free_trial.enabled", true);
+        SubscriptionBuildersClub.FREE_TRIAL_LIMIT = Emulator.getConfig().getInt("builders.club.free_trial.limit", 50);
+        SubscriptionBuildersClub.EXPIRY_WARNING_SECONDS = Emulator.getConfig()
+                .getInt("builders.club.expiry.warning.seconds", 86400);
 
         SubscriptionHabboClub.HC_PAYDAY_STREAK.clear();
-        for (String streak : Emulator.getConfig().getValue("subscriptions.hc.payday.streak", "7=5;30=10;60=15;90=20;180=25;365=30").split(Pattern.quote(";"))) {
-            if(streak.contains("=")) {
-                SubscriptionHabboClub.HC_PAYDAY_STREAK.put(Integer.parseInt(streak.split(Pattern.quote("="))[0]), Integer.parseInt(streak.split(Pattern.quote("="))[1]));
+        for (String streak : Emulator.getConfig()
+                .getValue("subscriptions.hc.payday.streak", "7=5;30=10;60=15;90=20;180=25;365=30")
+                .split(Pattern.quote(";"))) {
+            if (streak.contains("=")) {
+                SubscriptionHabboClub.HC_PAYDAY_STREAK.put(Integer.parseInt(streak.split(Pattern.quote("="))[0]),
+                        Integer.parseInt(streak.split(Pattern.quote("="))[1]));
             }
         }
 
-        ClothingValidationManager.VALIDATE_ON_HC_EXPIRE = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onhcexpired", false);
-        ClothingValidationManager.VALIDATE_ON_LOGIN = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onlogin", false);
-        ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onchangelooks", false);
-        ClothingValidationManager.VALIDATE_ON_MIMIC = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onmimic", false);
-        ClothingValidationManager.VALIDATE_ON_MANNEQUIN = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onmannequin", false);
-        ClothingValidationManager.VALIDATE_ON_FBALLGATE = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onfballgate", false);
+        ClothingValidationManager.VALIDATE_ON_HC_EXPIRE = Emulator.getConfig()
+                .getBoolean("hotel.users.clothingvalidation.onhcexpired", false);
+        ClothingValidationManager.VALIDATE_ON_LOGIN = Emulator.getConfig()
+                .getBoolean("hotel.users.clothingvalidation.onlogin", false);
+        ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS = Emulator.getConfig()
+                .getBoolean("hotel.users.clothingvalidation.onchangelooks", false);
+        ClothingValidationManager.VALIDATE_ON_MIMIC = Emulator.getConfig()
+                .getBoolean("hotel.users.clothingvalidation.onmimic", false);
+        ClothingValidationManager.VALIDATE_ON_MANNEQUIN = Emulator.getConfig()
+                .getBoolean("hotel.users.clothingvalidation.onmannequin", false);
+        ClothingValidationManager.VALIDATE_ON_FBALLGATE = Emulator.getConfig()
+                .getBoolean("hotel.users.clothingvalidation.onfballgate", false);
 
         String newUrl = Emulator.getConfig().getValue("gamedata.figuredata.url");
-        if(!ClothingValidationManager.FIGUREDATA_URL.equals(newUrl)) {
+        if (!ClothingValidationManager.FIGUREDATA_URL.equals(newUrl)) {
             ClothingValidationManager.FIGUREDATA_URL = newUrl;
             ClothingValidationManager.reloadFiguredata(newUrl);
         }
 
-        if(newUrl.isEmpty()) {
+        if (newUrl.isEmpty()) {
             ClothingValidationManager.VALIDATE_ON_HC_EXPIRE = false;
             ClothingValidationManager.VALIDATE_ON_LOGIN = false;
             ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS = false;
@@ -234,7 +275,6 @@ public class PluginManager {
             Emulator.getGameEnvironment().getCatalogManager().reloadBuildersClubCatalogRegistry();
         }
 
-
         UserEventCatsMessageComposer.CATEGORIES.clear();
         for (String category : Emulator.getConfig().getValue("navigator.eventcategories", "").split(";")) {
             try {
@@ -245,8 +285,12 @@ public class PluginManager {
         }
 
         if (Emulator.isReady) {
-            GiftWrappingConfigurationMessageComposer.BOX_TYPES = Arrays.stream(Emulator.getConfig().getValue("hotel.gifts.box_types").split(",")).mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
-            GiftWrappingConfigurationMessageComposer.RIBBON_TYPES = Arrays.stream(Emulator.getConfig().getValue("hotel.gifts.ribbon_types").split(",")).mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+            GiftWrappingConfigurationMessageComposer.BOX_TYPES = Arrays
+                    .stream(Emulator.getConfig().getValue("hotel.gifts.box_types").split(","))
+                    .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+            GiftWrappingConfigurationMessageComposer.RIBBON_TYPES = Arrays
+                    .stream(Emulator.getConfig().getValue("hotel.gifts.ribbon_types").split(","))
+                    .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
 
             Emulator.getGameEnvironment().getCreditsScheduler().reloadConfig();
             Emulator.getGameEnvironment().getPointsScheduler().reloadConfig();
@@ -271,7 +315,7 @@ public class PluginManager {
             URLClassLoader urlClassLoader;
             InputStream stream;
             try {
-                urlClassLoader = URLClassLoader.newInstance(new URL[]{file.toURI().toURL()});
+                urlClassLoader = URLClassLoader.newInstance(new URL[] { file.toURI().toURL() });
                 stream = urlClassLoader.getResourceAsStream("plugin.json");
 
                 if (stream == null) {
@@ -331,11 +375,13 @@ public class PluginManager {
 
     public <T extends Event> T fireEvent(T event) {
         for (Method method : this.methods) {
-            if (method.getParameterTypes().length == 1 && method.getParameterTypes()[0].isAssignableFrom(event.getClass())) {
+            if (method.getParameterTypes().length == 1
+                    && method.getParameterTypes()[0].isAssignableFrom(event.getClass())) {
                 try {
                     method.invoke(null, event);
                 } catch (Exception e) {
-                    LOGGER.error("Could not pass default event {} to {}: {}!", event.getClass().getName(), method.getClass().getName(), method.getName());
+                    LOGGER.error("Could not pass default event {} to {}: {}!", event.getClass().getName(),
+                            method.getClass().getName(), method.getName());
                     LOGGER.error("Caught exception", e);
                 }
             }
@@ -354,7 +400,8 @@ public class PluginManager {
                             try {
                                 method.invoke(plugin, event);
                             } catch (Exception e) {
-                                LOGGER.error("Could not pass event {} to {}", event.getClass().getName(), plugin.configuration.name);
+                                LOGGER.error("Could not pass event {} to {}", event.getClass().getName(),
+                                        plugin.configuration.name);
                                 LOGGER.error("Caught exception", e);
                             }
                         }
@@ -429,7 +476,8 @@ public class PluginManager {
 
         this.loadPlugins();
 
-        LOGGER.info("Plugin Manager -> Loaded! {} plugins! ({} MS)", this.plugins.size(), System.currentTimeMillis() - millis);
+        LOGGER.info("Plugin Manager -> Loaded! {} plugins! ({} MS)", this.plugins.size(),
+                System.currentTimeMillis() - millis);
 
         this.registerDefaultEvents();
     }
@@ -442,10 +490,12 @@ public class PluginManager {
             this.methods.add(TagGame.class.getMethod("onUserWalkEvent", UserTakeStepEvent.class));
             this.methods.add(FreezeGame.class.getMethod("onConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
             this.methods.add(PacketManager.class.getMethod("onConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
-            this.methods.add(InteractionFootballGate.class.getMethod("onUserDisconnectEvent", UserDisconnectEvent.class));
+            this.methods
+                    .add(InteractionFootballGate.class.getMethod("onUserDisconnectEvent", UserDisconnectEvent.class));
             this.methods.add(InteractionFootballGate.class.getMethod("onUserExitRoomEvent", UserExitRoomEvent.class));
             this.methods.add(InteractionFootballGate.class.getMethod("onUserSavedLookEvent", UserSavedLookEvent.class));
-            this.methods.add(PluginManager.class.getMethod("globalOnConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
+            this.methods.add(
+                    PluginManager.class.getMethod("globalOnConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
             this.methods.add(WiredHighscoreManager.class.getMethod("onEmulatorLoaded", EmulatorLoadedEvent.class));
             this.methods.add(WiredManager.class.getMethod("onEmulatorLoaded", EmulatorLoadedEvent.class));
         } catch (NoSuchMethodException e) {

--- a/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -24,6 +24,7 @@ import com.eu.habbo.habbohotel.users.clothingvalidation.ClothingValidationManage
 import com.eu.habbo.habbohotel.users.HabboInventory;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionHabboClub;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionBuildersClub;
 import com.eu.habbo.habbohotel.wired.core.WiredEngine;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
@@ -188,6 +189,18 @@ public class PluginManager {
         SubscriptionHabboClub.DISCOUNT_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.discount.enabled", false);
         SubscriptionHabboClub.DISCOUNT_DAYS_BEFORE_END = Emulator.getConfig().getInt("subscriptions.hc.discount.days_before_end", 7);
 
+        SubscriptionBuildersClub.ENABLED = Emulator.getConfig().getBoolean("builders.club.enabled", false);
+        SubscriptionBuildersClub.FURNI_LIMIT = Emulator.getConfig().getInt("builders.club.furni.limit", 75);
+        SubscriptionBuildersClub.MAX_FURNI_LIMIT = Emulator.getConfig().getInt("builders.club.max.furni.limit", 250);
+        SubscriptionBuildersClub.BOX_FURNI_LIMIT_INCREMENT = Emulator.getConfig().getInt("builders.club.box.furni.limit.increment", 750);
+        SubscriptionBuildersClub.GRACE_SECONDS = Emulator.getConfig().getInt("builders.club.grace.seconds", 0);
+        SubscriptionBuildersClub.GROUP_ROOM_PLACEMENT_ENABLED = Emulator.getConfig().getBoolean("builders.club.furniture.placement.group.room.enabled", false);
+        SubscriptionBuildersClub.EXPIRY_ACTION = Emulator.getConfig().getValue("builders.club.expiry.action", "none");
+        SubscriptionBuildersClub.ACHIEVEMENT_NAME = Emulator.getConfig().getValue("builders.club.achievement", "BuildersClub");
+        SubscriptionBuildersClub.BUY_MEMBERSHIP_PAGE = Emulator.getConfig().getValue("builders.club.buy_membership_page", "");
+        SubscriptionBuildersClub.TRY_PAGE = Emulator.getConfig().getValue("builders.club.try_page", "");
+        CatalogManager.BUILDERS_CLUB_FURNIDATA_URL = Emulator.getConfig().getValue("builders.club.furnidata.url", "");
+
         SubscriptionHabboClub.HC_PAYDAY_STREAK.clear();
         for (String streak : Emulator.getConfig().getValue("subscriptions.hc.payday.streak", "7=5;30=10;60=15;90=20;180=25;365=30").split(Pattern.quote(";"))) {
             if(streak.contains("=")) {
@@ -215,6 +228,10 @@ public class PluginManager {
             ClothingValidationManager.VALIDATE_ON_MIMIC = false;
             ClothingValidationManager.VALIDATE_ON_MANNEQUIN = false;
             ClothingValidationManager.VALIDATE_ON_FBALLGATE = false;
+        }
+
+        if (Emulator.isReady) {
+            Emulator.getGameEnvironment().getCatalogManager().reloadBuildersClubCatalogRegistry();
         }
 
 

--- a/src/main/java/com/eu/habbo/threading/runnables/teleport/TeleportActionThree.java
+++ b/src/main/java/com/eu/habbo/threading/runnables/teleport/TeleportActionThree.java
@@ -46,7 +46,7 @@ class TeleportActionThree implements Runnable {
             targetRoom.loadData();
         }
 
-        targetTeleport = targetRoom.getHabboItem(((InteractionTeleport) this.currentTeleport).getTargetId());
+        targetTeleport = targetRoom.getHabboItemByDatabaseId(((InteractionTeleport) this.currentTeleport).getTargetId());
 
         if (targetTeleport == null) {
             Emulator.getThreading().run(new TeleportActionFive(this.currentTeleport, this.room, this.client), 0);

--- a/src/main/java/com/eu/habbo/threading/runnables/teleport/TeleportActionTwo.java
+++ b/src/main/java/com/eu/habbo/threading/runnables/teleport/TeleportActionTwo.java
@@ -49,7 +49,7 @@ class TeleportActionTwo implements Runnable {
         this.room.sendComposer(new UserUpdateMessageComposer(this.client.getHabbo().getRoomUnit()).compose());
 
         if (((InteractionTeleport) this.currentTeleport).getTargetRoomId() > 0 && ((InteractionTeleport) this.currentTeleport).getTargetId() > 0) {
-            HabboItem item = this.room.getHabboItem(((InteractionTeleport) this.currentTeleport).getTargetId());
+            HabboItem item = this.room.getHabboItemByDatabaseId(((InteractionTeleport) this.currentTeleport).getTargetId());
             if (item == null) {
                 ((InteractionTeleport) this.currentTeleport).setTargetRoomId(0);
                 ((InteractionTeleport) this.currentTeleport).setTargetId(0);


### PR DESCRIPTION
## Summary

This PR adds end-to-end Builder's Club support to the server to match the current Habbo client contract.

It includes:

- Builder's Club as a real subscription type
- BC catalog mode support
- real BC status/count packet handling
- BC furniture placement handlers
- BC furniture lifecycle rules
- per-user BC furni limits
- furnidata-driven BC catalog filtering

It also includes follow-up fixes found during implementation:

- restore normal catalog visibility after the initial BC filter regression
- fix catalog wire-id / offer-id mismatches that caused `builders_club.invalid_offer`
- prevent normal item creation from drifting into the reserved BC id range

## Main Changes

### Subscription and User State

- Adds `BUILDERS_CLUB` as a real subscription type
- Sends real `1452` and `3828` values
- Tracks BC furni limits per user instead of using one global runtime value
- BC crackable rewards now increase the user's BC limit by `750`

### Catalog and Placement

- Adds `catalog_pages.catalog_type` with `NORMAL` and `BUILDERS_CLUB`
- Separates BC catalog mode from normal catalog mode
- Filters BC placement pages using furnidata `<bc>1</bc>` plus matching `offer_id`
- Excludes unsupported bundle / multi-offer structures from BC placement pages
- Adds BC placement packet support:
  - `1051` room item placement
  - `462` wall item placement

### BC Furniture Lifecycle

- BC furniture is persisted as room items in `items`
- BC item ids still use the reserved range `>= 0x7FFF0000`
- Picking up BC furniture deletes it instead of returning it to inventory
- Adds `:pickallbc`
- Adds BC expiry handling and BC room lock behavior

### Follow-up Fixes

- Restores normal single-item catalog offers after the initial BC regression
- Fixes catalog serialization / lookup so the client and server agree on offer ids
- Protects normal item creation with a dedicated low-range sequence so normal items no longer spill into the BC range

## Schema / Config

This PR expects the SQL in:

- `sqlupdates/4_0_3-beta_TO_4_0_4-beta.sql`

### Schema additions

- `catalog_pages.catalog_type`
- `catalog_items.subscription_type`
- `catalog_items.subscription_days`
- `users_settings.builders_club_furni_limit`
- `users_settings.builders_club_max_furni_limit`
- `builders_club_item_sequence`
- `items_item_sequence`

### Important settings

- `builders.club.enabled`
- `builders.club.box.furni.limit.increment`
- `builders.club.furnidata.url`
- `builders.club.expiry.action`

## Important Notes

- This implementation still uses real high item ids for BC furniture:
  - `items.id >= 0x7FFF0000`
- That is intentional for compatibility with the current client contract
- Normal item allocation is now protected so ordinary purchases should not enter that range anymore
- The unrelated trading event filename fix was split out separately and is not part of this PR

## Review Focus

### Client Contract

Please compare the branch against the local client behavior, especially around:

- BC catalog mode
- BC placement flow
- offer id handling
- BC item identification in-room

Suggested client references:

- `HabboCatalog.as`
- `CatalogPageMessageOfferData.as`
- `BuildersClubTools.as`
- `InfoStandWidgetHandler.as`

### Server Hotspots

Please pay closest attention to:

- `CatalogManager.java`
- `CatalogItem.java`
- `ItemManager.java`
- `HabboStats.java`
- `SubscriptionBuildersClub.java`

## Behavior To Verify

### Normal Catalog

- Normal pages still show items
- Buying normal furni gives normal inventory items
- Bought normal items do not appear as BC items in infostand
- Normal gifting and room-ad purchase flows still work

### Builder's Club Catalog

- `NORMAL` and `BUILDERS_CLUB` indexes/pages are separated correctly
- BC pages only show valid BC-compatible offers from furnidata + SQL
- Bundle / multi offers do not appear on BC placement pages

### Offer Id / Packet Correctness

- Catalog offer selection uses the real `offer_id`, not the catalog row id
- BC placement no longer throws `builders_club.invalid_offer` for valid offers
- Recent purchases and gifting still work after the wire-id fix

### Membership / Limits

- Login sends real `1452` and `3828` values
- `BUILDER_AT_WORK` matches effective BC entitlement
- Users with no effective BC get `0` BC limits from the server
- BC crackable rewards increase that user's limit by `750`
- BC count reflects placed BC items only

### In-Room BC Behavior

- Floor and wall BC placement succeed for valid offers
- Placement fails correctly for invalid page, invalid offer, wrong type, no rights, or limit reached
- Group room placement only works when config allows it
- Picking up a BC item deletes it instead of returning it to inventory
- `:pickallbc` removes only that owner's BC items
- Expiry action `pickup` deletes BC items
- Expiry action `lock` blocks guests from entering BC-item rooms when intended

### Room Reload / Floorplan

- Saving the floorplan should not produce a fake BC furniture removal notification
- Room reload should not spam misleading BC lock / unlock bubbles

## Risks To Review Carefully

- BC identity still relies on real high ids `>= 0x7FFF0000`
- Normal item allocation must stay below that reserved range
- Catalog wire-id changes are broad, so all `getCatalogItemByWireId` paths should be reviewed carefully
- If `builders.club.furnidata.url` is blank or wrong, BC pages may appear empty
- The SQL migration currently uses `ADD COLUMN IF NOT EXISTS`, which may need an older-MySQL-safe variant depending on deployment target
