### PR TITLE
fix: rate limiter allows limit+1 packets per window

### DIFF
--- a/src/main/java/com/eu/habbo/networking/gameserver/decoders/GameMessageRateLimit.java
+++ b/src/main/java/com/eu/habbo/networking/gameserver/decoders/GameMessageRateLimit.java
@@ -36,7 +36,7 @@ public class GameMessageRateLimit extends MessageToMessageDecoder<ClientMessage>
         }
 
         // If we exceeded the counter, drop the packet.
-        if (count > MAX_COUNTER) {
+        if (count >= MAX_COUNTER) {
             return;
         }
 


### PR DESCRIPTION
Resolves #19.

`count > MAX_COUNTER` lets through one extra packet because the check runs before the increment. Switching to `>=` enforces the documented `MAX_COUNTER = 10` limit inclusively, so the 11th packet in a window is dropped instead of accepted.