### PR TITLE
Fix negative rotation crash in setRotation()

### DIFF
--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
@@ -217,7 +217,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     }
 
     public void setRotation(int rotation) {
-        this.rotation = (byte) (rotation % 8);
+        this.rotation = (byte) (((rotation % 8) + 8) % 8);
     }
 
     public String getExtradata() {


### PR DESCRIPTION
setRotation() normalized incoming values with `rotation % 8`, but Java's % operator preserves the sign of its operand for negative inputs (e.g. -1 % 8 == -1, not 7). A client-supplied negative rotation — sent via a modified MoveObject packet, which is never validated before reaching this method — was therefore stored as a negative byte instead of being wrapped into the valid 0-7 range.

Downstream code indexes RoomUserRotation.values() directly with the stored rotation (e.g. during room-tick sit/lay processing). A negative index throws ArrayIndexOutOfBoundsException, which propagates out of the per-user tick loop and is only caught by the outer exception handler around the whole room cycle — silently skipping bot/pet/ roller/queue processing for that tick. Because the malformed rotation persists on the item, this repeats every tick until the item is fixed or removed, effectively freezing background room processing.

Fix: use the standard non-negative modulo idiom
`((rotation % 8) + 8) % 8`, which guarantees a 0-7 result regardless of the sign of the input. Since all rotation storage goes through this setter, this closes the issue at every call site at once, including any not yet audited.