### PR TITLE
Fix negative rotation crash in setRotation()

### DIFF
--- a/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -1504,7 +1504,8 @@ public class RoomItemManager {
             return FurnitureMovementError.INVALID_MOVE;
         }
 
-        rotation %= 8;
+        rotation = RoomLayout.normalizeRotation(rotation);
+
         if (this.room.hasRights(habbo) || this.room.getGuildRightLevel(habbo)
                 .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS)
                 || habbo.hasPermission(

--- a/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
+++ b/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
@@ -82,8 +82,12 @@ public class RoomLayout {
         Math.abs(one.y - two.y) > 1);
   }
 
+  public static int normalizeRotation(int rotation) {
+    return ((rotation % 8) + 8) % 8;
+  }
+
   public static Rectangle getRectangle(int x, int y, int width, int length, int rotation) {
-    rotation = (rotation % 8);
+    rotation = normalizeRotation(rotation);
 
     if (rotation == 2 || rotation == 6) {
       return new Rectangle(x, y, length, width);
@@ -383,6 +387,7 @@ public class RoomLayout {
   }
 
   public boolean fitsOnMap(RoomTile tile, int width, int length, int rotation) {
+    rotation = normalizeRotation(rotation);
     if (tile != null) {
       if (rotation == 0 || rotation == 4) {
         for (short i = tile.x; i <= (tile.x + (width - 1)); i++) {
@@ -416,6 +421,7 @@ public class RoomLayout {
   }
 
   public THashSet<RoomTile> getTilesAt(RoomTile tile, int width, int length, int rotation) {
+    rotation = normalizeRotation(rotation);
     THashSet<RoomTile> pointList = new THashSet<>(width * length, 0.1f);
 
     if (tile != null) {

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
@@ -71,7 +71,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
         this.x = set.getShort("x");
         this.y = set.getShort("y");
         this.z = set.getDouble("z");
-        this.rotation = set.getInt("rot");
+        this.rotation = ((set.getInt("rot") % 8) + 8) % 8;
         this.extradata = set.getString("extra_data").isEmpty() ? "0" : set.getString("extra_data");
 
         String ltdData = set.getString("limited_data");
@@ -217,7 +217,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     }
 
     public void setRotation(int rotation) {
-        this.rotation = (byte) (((rotation % 8) + 8) % 8);
+        this.rotation = ((rotation % 8) + 8) % 8;
     }
 
     public String getExtradata() {

--- a/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
+++ b/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
@@ -217,7 +217,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
     }
 
     public void setRotation(int rotation) {
-        this.rotation = (byte) (rotation % 8);
+        this.rotation = (byte) (((rotation % 8) + 8) % 8);
     }
 
     public String getExtradata() {

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
@@ -18,7 +18,7 @@ public class BuildersClubPlaceRoomItemMessageEvent extends MessageHandler {
         String extraData = this.packet.readString();
         short x = this.packet.readInt().shortValue();
         short y = this.packet.readInt().shortValue();
-        int rotation = this.packet.readInt();
+        int rotation = RoomLayout.normalizeRotation(this.packet.readInt());
         boolean confirmHideRoom = this.packet.readBoolean();
 
         // Check trial warning condition before validate() reserves a slot.

--- a/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemMessageEvent.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
 import com.eu.habbo.habbohotel.rooms.RoomState;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoveObjectMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoveObjectMessageEvent.java
@@ -23,7 +23,7 @@ public class MoveObjectMessageEvent extends MessageHandler {
 
         int x = this.packet.readInt();
         int y = this.packet.readInt();
-        int rotation = this.packet.readInt();
+        int rotation = RoomLayout.normalizeRotation(this.packet.readInt());
         RoomTile tile = room.getLayout().getTile((short) x, (short) y);
 
         FurnitureMovementError error = room.canPlaceFurnitureAt(item, this.client.getHabbo(), tile, rotation);

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoveObjectMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoveObjectMessageEvent.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
 import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;

--- a/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PlaceObjectMessageEvent.java
+++ b/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PlaceObjectMessageEvent.java
@@ -55,7 +55,7 @@ public class PlaceObjectMessageEvent extends MessageHandler {
         if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
             short x = Short.parseShort(values[1]);
             short y = Short.parseShort(values[2]);
-            int rotation = Integer.parseInt(values[3]);
+            int rotation = RoomLayout.normalizeRotation(Integer.parseInt(values[3]));
 
             RoomTile tile = room.getLayout().getTile(x, y);
 


### PR DESCRIPTION
setRotation() normalized incoming values with `rotation % 8`, but Java's % operator preserves the sign of its operand for negative inputs (e.g. -1 % 8 == -1, not 7). A client-supplied negative rotation — sent via a modified MoveObject packet, which is never validated before reaching this method — was therefore stored as a negative byte instead of being wrapped into the valid 0-7 range.

Downstream code indexes RoomUserRotation.values() directly with the stored rotation (e.g. during room-tick sit/lay processing). A negative index throws ArrayIndexOutOfBoundsException, which propagates out of the per-user tick loop and is only caught by the outer exception handler around the whole room cycle — silently skipping bot/pet/ roller/queue processing for that tick. Because the malformed rotation persists on the item, this repeats every tick until the item is fixed or removed, effectively freezing background room processing.

Fix: use the standard non-negative modulo idiom
`((rotation % 8) + 8) % 8`, which guarantees a 0-7 result regardless of the sign of the input. Since all rotation storage goes through this setter, this closes the issue at every call site at once, including any not yet audited.